### PR TITLE
Clarify docker instructions, add basic compose.yaml support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ accounts.json
 notes
 accounts.dev.json
 accounts.main.json
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -17,9 +17,26 @@ Under development, however mainly for personal use!
 
 ## Docker (Experimental) ##
 1. Download the source code
-2. Make changes to your `accounts.json` and/or `config.json`
-3. Run `docker build -t microsoft-rewards-script-docker .`
-- Docker container has to be recreated for any changes regarding the `config.json` and/or `accounts.json`!
+2. Make changes to your `accounts.json`
+3. Make sure to change `"headless": false` to `"headless": true` in your `config.json` 
+4. Note, the container has to be recreated for any changes regarding the `config.json` and/or `accounts.json`!
+### Option 1: build and run with docker run
+
+1. Run `docker build -t microsoft-rewards-script-docker .` to build the container
+2. Run the container with `docker run --name netsky -d microsoft-rewards-script-docker` or, omit the detached flag `-d` to view the script output in your terminal. 
+3. Optionally, change the name of the container by changing `--name netsky` to your preferred container name
+4. The container will exit after completing the script, run it again using `docker start netsky`
+5. If you are running the container `-d` detached, you can view logs with `docker logs netsky`
+
+### Option 2: use docker compose
+
+1. A basic docker compose.yaml has been provided, which can be run with `docker compose up -d` or, omit the detached flag `-d` to view the script output in your terminal. 
+
+2. The container will exit after completing the script, run it again using `docker start netsky`
+
+3. If you are running the container `-d` detached, you can view logs with `docker logs netsky`
+
+   
 
 ## Config ## 
 | Setting        | Description           | Default  |

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,8 @@
+services:
+  microsoft-rewards-script:
+    build: .
+    container_name: netsky
+    environment:
+      - NODE_ENV=production
+    volumes:
+      - .:/usr/src/microsoft-rewards-script


### PR DESCRIPTION
This should help folks get started with docker and hopefully make it easier for testing. 

I have not made any changes whatsoever to the underlying script or the dockerfile. I have created a simple compose.yaml file, which I find much easier to use when deploying docker containers, and added/clarified some instructions in the README.md.

The compose file is very basic, and should work as expected. Note that I made the container name `netsky`. If you prefer to use a different container name, please feelf ree to change it in the `container_name:` values in the compose, in the `docker run` command that I added to the README.md, and in the `docker start` commands in the README.md.

Thanks again, and my testing is tracked in #89, where I also included some basic suggestions to automatically schedule daily runs of the docker container if folks are interested.