### PR TITLE
Bug when detecting earnable points from more promotions

### DIFF
--- a/src/browser/BrowserFunc.ts
+++ b/src/browser/BrowserFunc.ts
@@ -158,7 +158,7 @@ export default class BrowserFunc {
             if (data.morePromotions?.length) {
                 data.morePromotions.forEach(x => {
                     // Only count points from supported activities
-                    if (['quiz', 'urlreward'].includes(x.activityType)) {
+                    if (['quiz', 'urlreward'].includes(x.promotionType)) {
                         totalEarnablePoints += (x.pointProgressMax - x.pointProgress)
                     }
                 })


### PR DESCRIPTION
Fix bug where the script was using `x.activityType` instead of `x.promotionType` this was causing that the script wasn't detecting earnable points from more promotions