### PR TITLE
Fix login - email can be pre-filled

### DIFF
--- a/src/functions/Login.ts
+++ b/src/functions/Login.ts
@@ -56,11 +56,17 @@ export class Login {
 
     private async execLogin(page: Page, email: string, password: string) {
         try {
-            // Enter email
-            await page.fill('#i0116', email)
-            await page.click('#idSIButton9')
+            const isPrefilledEmail = await this.checkPrefilledEmail(page, email)
 
-            this.bot.log('LOGIN', 'Email entered successfully')
+            if (isPrefilledEmail) {
+                this.bot.log('LOGIN', 'Email already pre-filled')
+            } else {
+                // Enter email
+                await page.fill('#i0116', email)
+                await page.click('#idSIButton9')
+
+                this.bot.log('LOGIN', 'Email entered successfully')
+            }
 
             try {
                 // Enter password
@@ -136,6 +142,20 @@ export class Login {
         try {
             await page.waitForSelector('#id_n', { timeout: 5000 })
             return true
+        } catch (error) {
+            return false
+        }
+    }
+
+    private async checkPrefilledEmail(page: Page, email: string): Promise<boolean> {
+        try {
+            const prefilled = await page.getByTestId('login').inputValue()
+
+            if (prefilled == email) {
+                return true
+            }
+            
+            return false
         } catch (error) {
             return false
         }


### PR DESCRIPTION
Hello, I have prepared PR with a fix for login.

I have a problem with one of my accounts. When this account tries to log in without a saved session, it's OK. But when try to log in with the saved session, the script ends with the error same as #93.

If I delete the session, everything works OK, until the next run. It's very annoying to delete a session every run.

After some debugging, I noticed that the login email may already be prefilled.

I added the check for prefilled email. If detected, then skip filling email and go fill password.