### PR TITLE
Docker update: Build script entirely in container, better handling of config options through docker env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,14 @@ FROM node:18
 # Set the working directory in the container
 WORKDIR /usr/src/microsoft-rewards-script
 
-# Install necessary packages including jq, cron, gettext-base, and dependencies for Playwright
-RUN apt-get update && apt-get install -y \
-    jq \
-    cron \
-    gettext-base \
+# Install jq, cron, and gettext-base
+RUN apt-get update && apt-get install -y jq cron gettext-base
+
+# Copy all files to the working directory
+COPY . .
+
+# Install dependencies including Playwright
+RUN apt-get install -y \
     xvfb \
     libgbm-dev \
     libnss3 \
@@ -18,16 +21,13 @@ RUN apt-get update && apt-get install -y \
     libgtk-3-0 \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy all files from the current directory (repository) to the working directory in the container
-COPY . .
-
 # Install application dependencies
 RUN npm install
 
 # Build the script
 RUN npm run build
 
-# Install Playwright Chromium
+# Install playwright chromium
 RUN npx playwright install chromium
 
 # Copy cron file to cron directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,11 @@ FROM node:18
 # Set the working directory in the container
 WORKDIR /usr/src/microsoft-rewards-script
 
-# Install jq, cron, and gettext-base
-RUN apt-get update && apt-get install -y jq cron gettext-base
-
-# Copy all files to the working directory
-COPY . .
-
-# Install dependencies including Playwright
-RUN apt-get install -y \
+# Install necessary packages including jq, cron, gettext-base, and dependencies for Playwright
+RUN apt-get update && apt-get install -y \
+    jq \
+    cron \
+    gettext-base \
     xvfb \
     libgbm-dev \
     libnss3 \
@@ -21,13 +18,16 @@ RUN apt-get install -y \
     libgtk-3-0 \
     && rm -rf /var/lib/apt/lists/*
 
+# Copy all files from the current directory (repository) to the working directory in the container
+COPY . .
+
 # Install application dependencies
 RUN npm install
 
 # Build the script
 RUN npm run build
 
-# Install playwright chromium
+# Install Playwright Chromium
 RUN npx playwright install chromium
 
 # Copy cron file to cron directory

--- a/README.md
+++ b/README.md
@@ -16,28 +16,40 @@ Under development, however mainly for personal use!
 - If you automate this script, set it to run at least 2 times a day to make sure it picked up all tasks, set `"runOnZeroPoints": false` so it doesn't run when no points are found.
 
 ## Docker (Experimental) ##
-1. Download the source code
-2. Make changes to your `accounts.json`
-3. **Headless mode must be enabled when using Docker.** You can do this using the `HEADLESS=true` environmental variable in docker run or docker compose.yaml (see below). Environmental variables are always prioritized over the values in config.json. 
-4. The container will run scheduled. Customize your schedule using the `CRON_START_TIME` environmental variable. Use [crontab.guru](crontab.guru) if you're unsure how to create a cron schedule.
-5. **Note:** the container will add between 5 and 50 minutes of randomized variability to your scheduled start times. 
+1. Clone the repository:
+
+   ```bash
+   git clone https://github.com/TheNetsky/Microsoft-Rewards-Script
+   cd Microsoft-Rewards-Script
+   ```
+
+2. Copy `accounts.example.json` to `accounts.json` and update it with your account details.
+
+   ```bash
+   cp accounts.example.json accounts.json
+   ```
+
+3. Modify `config.json` as needed.
+
+4. **Headless mode must be enabled when using Docker.** You can do this using the `HEADLESS=true` environmental variable in docker run or docker compose.yaml (see below). Environmental variables are always prioritized over the values in config.json. 
+
+5. The container will run scheduled. Customize your schedule using the `CRON_START_TIME` environmental variable. Use [crontab.guru](crontab.guru) if you're unsure how to create a cron schedule.
+
+6. **Note:** the container will add between 5 and 50 minutes of randomized variability to your scheduled start times. 
 ### Option 1: build and run with docker run
 
 1. Build or re-build the container image with: `docker build -t microsoft-rewards-script-docker .` 
 
-2. Run the container with:
+2. Then,  for example, run the container with:
 
    ```bash
    docker run --name netsky -d \
    -e TZ=America/New_York \
    -e HEADLESS=true \
-   -e SEARCH_DELAY_MIN=10000 \
-   -e SEARCH_DELAY_MAX=20000 \
-   -e CLUSTERS=1 \
    -e CRON_START_TIME="0 5,11 * * *" \
    microsoft-rewards-script-docker
    ```
-
+   
 3. Optionally, change any environmental variables other than `HEADLESS`, which must stay `=true`
 
 4. You can view logs with `docker logs netsky`.

--- a/README.md
+++ b/README.md
@@ -16,12 +16,7 @@ Under development, however mainly for personal use!
 - If you automate this script, set it to run at least 2 times a day to make sure it picked up all tasks, set `"runOnZeroPoints": false` so it doesn't run when no points are found.
 
 ## Docker (Experimental) ##
-1. Clone the repository:
-
-   ```bash
-   git clone https://github.com/TheNetsky/Microsoft-Rewards-Script
-   cd Microsoft-Rewards-Script
-   ```
+1. Download the source code
 
 2. Copy `accounts.example.json` to `accounts.json` and update it with your account details.
 
@@ -29,7 +24,7 @@ Under development, however mainly for personal use!
    cp accounts.example.json accounts.json
    ```
 
-3. Modify `config.json` as needed.
+3. Modify `config.json` as needed
 
 4. **Headless mode must be enabled when using Docker.** You can do this using the `HEADLESS=true` environmental variable in docker run or docker compose.yaml (see below). Environmental variables are always prioritized over the values in config.json. 
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -24,16 +24,4 @@ services:
       - WEBHOOK_ENABLED=false
       - WEBHOOK_URL=
       - CRON_START_TIME="0 5,11 * * *"
-      # Accounts.json variables
-      - EMAIL_1=sample1@email.com
-      - PASSWORD_1=password1
-      - PROXY_URL_1=
-      - PROXY_PORT_1=0
-      - PROXY_USERNAME_1=
-      - PROXY_PASSWORD_1=
-      - EMAIL_2=sample2@email.com
-      - PASSWORD_2=password2
-      - PROXY_URL_2=
-      - PROXY_PORT_2=0
-      - PROXY_USERNAME_2=
-      - PROXY_PASSWORD_2=
+    restart: unless-stopped

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,14 +1,12 @@
 services:
   microsoft-rewards-script:
-    build: .
+    image: your_image_name_here
     container_name: netsky
     environment:
-      - TZ=America/Toronto #change to your local timezone
-      - NODE_ENV=production 
-      - HEADLESS=true #do not change
-      ### the following are optional, you only need to include them if you want to enter a custom value, removing them will use the default values
+      # Config.json variables
       - BASE_URL=https://rewards.bing.com
       - SESSION_PATH=sessions
+      - HEADLESS=false
       - RUN_ON_ZERO_POINTS=false
       - CLUSTERS=1
       - SAVE_FINGERPRINT=false
@@ -20,15 +18,22 @@ services:
       - SEARCH_SETTINGS_USE_GEO_LOCALE_QUERIES=false
       - SEARCH_SETTINGS_SCROLL_RANDOM_RESULTS=true
       - SEARCH_SETTINGS_CLICK_RANDOM_RESULTS=true
-      - SEARCH_SETTINGS_SEARCH_DELAY_MIN=10000 # Set the search delay longer, e.g. MIN=180000 and MAX=270000 if you live in a region where MS enforces a search cooldown
+      - SEARCH_SETTINGS_SEARCH_DELAY_MIN=10000
       - SEARCH_SETTINGS_SEARCH_DELAY_MAX=20000
       - SEARCH_SETTINGS_RETRY_MOBILE_SEARCH=true
       - WEBHOOK_ENABLED=false
       - WEBHOOK_URL=
-      ### Customize your run schedule, default 5:00 am and 11:00 am, use crontab.guru if you're not sure 
-      - CRON_START_TIME=0 5,11 * * *
-      ### Run on start, set as false to only run the script per the cron schedule
-      - RUN_ON_START=true 
-    restart: unless-stopped
-    volumes:
-      - .:/usr/src/microsoft-rewards-script
+      - CRON_START_TIME="0 5,11 * * *"
+      # Accounts.json variables
+      - EMAIL_1=sample1@email.com
+      - PASSWORD_1=password1
+      - PROXY_URL_1=
+      - PROXY_PORT_1=0
+      - PROXY_USERNAME_1=
+      - PROXY_PASSWORD_1=
+      - EMAIL_2=sample2@email.com
+      - PASSWORD_2=password2
+      - PROXY_URL_2=
+      - PROXY_PORT_2=0
+      - PROXY_USERNAME_2=
+      - PROXY_PASSWORD_2=

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   microsoft-rewards-script:
-    image: your_image_name_here
+    build: .
     container_name: netsky
     environment:
       # Config.json variables
@@ -24,4 +24,5 @@ services:
       - WEBHOOK_ENABLED=false
       - WEBHOOK_URL=
       - CRON_START_TIME="0 5,11 * * *"
+      - RUN_ON_START=true
     restart: unless-stopped

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,26 +3,27 @@ services:
     build: .
     container_name: netsky
     environment:
-      # Config.json variables
-      - BASE_URL=https://rewards.bing.com
-      - SESSION_PATH=sessions
-      - HEADLESS=false
-      - RUN_ON_ZERO_POINTS=false
-      - CLUSTERS=1
-      - SAVE_FINGERPRINT=false
-      - WORKERS_DO_DAILY_SET=true
-      - WORKERS_DO_MORE_PROMOTIONS=true
-      - WORKERS_DO_PUNCH_CARDS=true
-      - WORKERS_DO_DESKTOP_SEARCH=true
-      - WORKERS_DO_MOBILE_SEARCH=true
-      - SEARCH_SETTINGS_USE_GEO_LOCALE_QUERIES=false
-      - SEARCH_SETTINGS_SCROLL_RANDOM_RESULTS=true
-      - SEARCH_SETTINGS_CLICK_RANDOM_RESULTS=true
-      - SEARCH_SETTINGS_SEARCH_DELAY_MIN=10000
-      - SEARCH_SETTINGS_SEARCH_DELAY_MAX=20000
-      - SEARCH_SETTINGS_RETRY_MOBILE_SEARCH=true
-      - WEBHOOK_ENABLED=false
-      - WEBHOOK_URL=
-      - CRON_START_TIME="0 5,11 * * *"
-      - RUN_ON_START=true
+      BASE_URL: "https://rewards.bing.com"
+      SESSION_PATH: "sessions"
+      HEADLESS: "true"
+      RUN_ON_ZERO_POINTS: "false"
+      CLUSTERS: "1"
+      SAVE_FINGERPRINT: "false"
+      DO_DAILY_SET: "true"
+      DO_MORE_PROMOTIONS: "true"
+      DO_PUNCH_CARDS: "true"
+      DO_DESKTOP_SEARCH: "true"
+      DO_MOBILE_SEARCH: "true"
+      GLOBAL_TIMEOUT: "30000"
+      USE_GEO_LOCALE_QUERIES: "true"
+      SCROLL_RANDOM_RESULTS: "true"
+      CLICK_RANDOM_RESULTS: "true"
+      SEARCH_DELAY_MIN: "10000"
+      SEARCH_DELAY_MAX: "20000"
+      RETRY_MOBILE_SEARCH: "true"
+      WEBHOOK_ENABLED: "false"
+      WEBHOOK_URL: ""
+      CRON_START_TIME: "0 5,11 * * *"
+      TZ: "America/New_York"
+      RUN_ON_START: "true"    
     restart: unless-stopped

--- a/src/util/Load.ts
+++ b/src/util/Load.ts
@@ -28,12 +28,41 @@ export function loadAccounts(): Account[] {
 
 export function loadConfig(): Config {
     try {
-        const configDir = path.join(__dirname, '../', 'config.json')
-        const config = fs.readFileSync(configDir, 'utf-8')
+        const configDir = path.join(__dirname, '../', 'config.json');
+        const configContent = fs.readFileSync(configDir, 'utf-8');
+        const config: Config = JSON.parse(configContent);
 
-        return JSON.parse(config)
+        // Override with environment variables if provided
+        config.baseURL = process.env.BASE_URL || config.baseURL;
+        config.sessionPath = process.env.SESSION_PATH || config.sessionPath;
+        config.headless = process.env.HEADLESS ? process.env.HEADLESS === 'true' : config.headless;
+        config.runOnZeroPoints = process.env.RUN_ON_ZERO_POINTS ? process.env.RUN_ON_ZERO_POINTS === 'true' : config.runOnZeroPoints;
+        config.clusters = process.env.CLUSTERS ? parseInt(process.env.CLUSTERS) : config.clusters;
+        config.saveFingerprint = process.env.SAVE_FINGERPRINT ? process.env.SAVE_FINGERPRINT === 'true' : config.saveFingerprint;
+
+        config.workers.doDailySet = process.env.DO_DAILY_SET ? process.env.DO_DAILY_SET === 'true' : config.workers.doDailySet;
+        config.workers.doMorePromotions = process.env.DO_MORE_PROMOTIONS ? process.env.DO_MORE_PROMOTIONS === 'true' : config.workers.doMorePromotions;
+        config.workers.doPunchCards = process.env.DO_PUNCH_CARDS ? process.env.DO_PUNCH_CARDS === 'true' : config.workers.doPunchCards;
+        config.workers.doDesktopSearch = process.env.DO_DESKTOP_SEARCH ? process.env.DO_DESKTOP_SEARCH === 'true' : config.workers.doDesktopSearch;
+        config.workers.doMobileSearch = process.env.DO_MOBILE_SEARCH ? process.env.DO_MOBILE_SEARCH === 'true' : config.workers.doMobileSearch;
+
+        config.globalTimeout = process.env.GLOBAL_TIMEOUT ? parseInt(process.env.GLOBAL_TIMEOUT) : config.globalTimeout;
+
+        config.searchSettings.useGeoLocaleQueries = process.env.USE_GEO_LOCALE_QUERIES ? process.env.USE_GEO_LOCALE_QUERIES === 'true' : config.searchSettings.useGeoLocaleQueries;
+        config.searchSettings.scrollRandomResults = process.env.SCROLL_RANDOM_RESULTS ? process.env.SCROLL_RANDOM_RESULTS === 'true' : config.searchSettings.scrollRandomResults;
+        config.searchSettings.clickRandomResults = process.env.CLICK_RANDOM_RESULTS ? process.env.CLICK_RANDOM_RESULTS === 'true' : config.searchSettings.clickRandomResults;
+
+        config.searchSettings.searchDelay.min = process.env.SEARCH_DELAY_MIN ? parseInt(process.env.SEARCH_DELAY_MIN) : config.searchSettings.searchDelay.min;
+        config.searchSettings.searchDelay.max = process.env.SEARCH_DELAY_MAX ? parseInt(process.env.SEARCH_DELAY_MAX) : config.searchSettings.searchDelay.max;
+
+        config.searchSettings.retryMobileSearch = process.env.RETRY_MOBILE_SEARCH ? process.env.RETRY_MOBILE_SEARCH === 'true' : config.searchSettings.retryMobileSearch;
+
+        config.webhook.enabled = process.env.WEBHOOK_ENABLED ? process.env.WEBHOOK_ENABLED === 'true' : config.webhook.enabled;
+        config.webhook.url = process.env.WEBHOOK_URL || config.webhook.url;
+
+        return config;
     } catch (error) {
-        throw new Error(error as string)
+        throw new Error(error as string);
     }
 }
 


### PR DESCRIPTION
Docker changes:
### Build script within the container

- Changes to Dockerfile: The script should now be built entirely within the docker container when the docker image is built. As in, no need to install node.js locally or build the script once before switching to docker.
- Same install instructions - docker requires the source code, and `docker compose up -d --build` each time config options are changed. 

### Better handling of config options provided as environmental variables in compose.yaml

- **Note: Changes to Load.ts!** Since many of the config options are integrated into the script when it is built, I had to make changes to the Load.ts to optionally pass in config values when they are specified by the user as environmental variables in their compose file. 
- When building, the script should read/prioritize docker env var values, and if not specified, fall back to the original config.json values. 
- I did some testing on my own system to ensure that the changes to Load.ts didn't break the script for non-docker user. On my system it works either as a base script and as docker, but **please review the code changes for Load.ts.**
- Ideally, this means a docker user can specify all their config options directly in their compose.yaml.

As always, thank you for your work on this, and feel free to edit, change, ignore anything I've done here. 
