### PR TITLE
Support passwordless auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Under development, however mainly for personal use!
 - [x] Multi-Account Support
 - [x] Session Storing
 - [x] 2FA Support
+- [x] Passwordless Support
 - [x] Headless Support
 - [x] Discord Webhook Support
 - [x] Desktop Searches


### PR DESCRIPTION
I have a development with accounts that have turned on "Passwordless" option. When filled the email, it shows the number that the user has to press on the Authenticator app to approve the login.