### PR TITLE
Skip locked Promotions

### DIFF
--- a/src/browser/BrowserFunc.ts
+++ b/src/browser/BrowserFunc.ts
@@ -158,7 +158,7 @@ export default class BrowserFunc {
             if (data.morePromotions?.length) {
                 data.morePromotions.forEach(x => {
                     // Only count points from supported activities
-                    if (['quiz', 'urlreward'].includes(x.promotionType)) {
+                    if (['quiz', 'urlreward'].includes(x.promotionType) && !x.attributes.is_unlocked) {
                         totalEarnablePoints += (x.pointProgressMax - x.pointProgress)
                     }
                 })

--- a/src/functions/Workers.ts
+++ b/src/functions/Workers.ts
@@ -87,7 +87,7 @@ export class Workers {
             morePromotions.push(data.promotionalItem as unknown as MorePromotion)
         }
 
-        const activitiesUncompleted = morePromotions?.filter(x => !x.complete && x.pointProgressMax > 0) ?? []
+        const activitiesUncompleted = morePromotions?.filter(x => !x.complete && x.pointProgressMax > 0 && !x.attributes.is_unlocked) ?? [];
 
         if (!activitiesUncompleted.length) {
             this.bot.log('MORE-PROMOTIONS', 'All "More Promotion" items have already been completed')
@@ -149,7 +149,7 @@ export class Workers {
 
                 // Wait for the new tab to fully load, ignore error.
                 /*
-                Due to common false timeout on this function, we're ignoring the error regardless, if it worked then it's faster, 
+                Due to common false timeout on this function, we're ignoring the error regardless, if it worked then it's faster,
                 if it didn't then it gave enough time for the page to load.
                 */
                 await activityPage.waitForLoadState('networkidle', { timeout: 10_000 }).catch(() => { })


### PR DESCRIPTION
For users newly added to the rewards program, skip activities that are locked, i.e., activities requiring a level greater than 2.
![屏幕截图 2024-08-17 223700](https://github.com/user-attachments/assets/9e4949b1-dbf6-45fc-af22-1afbf9b00678)
