### PR TITLE
Automatically update the user agent string to show the latest Chrome/Edge versions

### DIFF
--- a/src/util/UserAgent.ts
+++ b/src/util/UserAgent.ts
@@ -109,23 +109,24 @@ export async function getAppComponents(mobile: boolean) {
     }
 }
 
-    // Function to update the version numbers
- export async function updateFingerprintUserAgent(fingerprint: BrowserFingerprintWithHeaders, mobile: boolean): Promise<BrowserFingerprintWithHeaders> {
-    // Get latest Chrome version in its reduced form
+export async function updateFingerprintUserAgent(fingerprint: BrowserFingerprintWithHeaders, mobile: boolean): Promise<BrowserFingerprintWithHeaders> {
     const app = await getAppComponents(mobile)
-    const chromeReducedVersion = app.chrome_reduced_version    
+    const chromeReducedVersion = app.chrome_reduced_version
     
-    // Regular expressions to find and replace the versions
     const chromeVersionRegex = /Chrome\/\d+\.\d+\.\d+\.\d+/
-    const edgeVersionRegex = /Edg\/\d+\.\d+\.\d+\.\d+/
+    fingerprint.fingerprint.navigator.userAgent = fingerprint.fingerprint.navigator.userAgent.replace(chromeVersionRegex, `Chrome/${chromeReducedVersion}`)
+    fingerprint.headers['user-agent'] = fingerprint.fingerprint.navigator.userAgent.replace(chromeVersionRegex, `Chrome/${chromeReducedVersion}`)
 
-    let updatedFingerprint = fingerprint
+    if (mobile) {
+        const edgeVersionRegex = /EdgA\/\d+\.\d+\.\d+\.\d+/
+        fingerprint.fingerprint.navigator.userAgent = fingerprint.fingerprint.navigator.userAgent.replace(edgeVersionRegex, `EdgA/${chromeReducedVersion}`)
+        fingerprint.headers['user-agent'] = fingerprint.fingerprint.navigator.userAgent.replace(edgeVersionRegex, `EdgA/${chromeReducedVersion}`)
+    }
+    else {
+        const edgeVersionRegex = /Edg\/\d+\.\d+\.\d+\.\d+/
+        fingerprint.fingerprint.navigator.userAgent = fingerprint.fingerprint.navigator.userAgent.replace(edgeVersionRegex, `Edg/${chromeReducedVersion}`)
+        fingerprint.headers['user-agent'] = fingerprint.fingerprint.navigator.userAgent.replace(edgeVersionRegex, `Edg/${chromeReducedVersion}`)
+    }
 
-    // Replace the old versions with the new ones
-    updatedFingerprint.fingerprint.navigator.userAgent = updatedFingerprint.fingerprint.navigator.userAgent.replace(edgeVersionRegex, `Edg/${chromeReducedVersion}`)
-    updatedFingerprint.headers['user-agent'] = updatedFingerprint.fingerprint.navigator.userAgent.replace(edgeVersionRegex, `Edg/${chromeReducedVersion}`)
-    updatedFingerprint.fingerprint.navigator.userAgent = updatedFingerprint.fingerprint.navigator.userAgent.replace(chromeVersionRegex, `Chrome/${chromeReducedVersion}`)
-    updatedFingerprint.headers['user-agent'] = updatedFingerprint.fingerprint.navigator.userAgent.replace(chromeVersionRegex, `Chrome/${chromeReducedVersion}`)
-
-    return updatedFingerprint
+    return fingerprint
 }

--- a/src/util/UserAgent.ts
+++ b/src/util/UserAgent.ts
@@ -1,4 +1,5 @@
 import axios from 'axios'
+import { BrowserFingerprintWithHeaders } from 'fingerprint-generator'
 
 import { log } from './Logger'
 
@@ -106,4 +107,25 @@ export async function getAppComponents(mobile: boolean) {
         chrome_major_version: chromeMajorVersion as string,
         chrome_reduced_version: chromeReducedVersion as string
     }
+}
+
+    // Function to update the version numbers
+ export async function updateFingerprintUserAgent(fingerprint: BrowserFingerprintWithHeaders, mobile: boolean): Promise<BrowserFingerprintWithHeaders> {
+    // Get latest Chrome version in its reduced form
+    const app = await getAppComponents(mobile)
+    const chromeReducedVersion = app.chrome_reduced_version    
+    
+    // Regular expressions to find and replace the versions
+    const chromeVersionRegex = /Chrome\/\d+\.\d+\.\d+\.\d+/
+    const edgeVersionRegex = /Edg\/\d+\.\d+\.\d+\.\d+/
+
+    let updatedFingerprint = fingerprint
+
+    // Replace the old versions with the new ones
+    updatedFingerprint.fingerprint.navigator.userAgent = updatedFingerprint.fingerprint.navigator.userAgent.replace(edgeVersionRegex, `Edg/${chromeReducedVersion}`)
+    updatedFingerprint.headers['user-agent'] = updatedFingerprint.fingerprint.navigator.userAgent.replace(edgeVersionRegex, `Edg/${chromeReducedVersion}`)
+    updatedFingerprint.fingerprint.navigator.userAgent = updatedFingerprint.fingerprint.navigator.userAgent.replace(chromeVersionRegex, `Chrome/${chromeReducedVersion}`)
+    updatedFingerprint.headers['user-agent'] = updatedFingerprint.fingerprint.navigator.userAgent.replace(chromeVersionRegex, `Chrome/${chromeReducedVersion}`)
+
+    return updatedFingerprint
 }


### PR DESCRIPTION
This solves #149 and ensures the latest major Chrome/Edge version is shown in the fingerprint's user agent (both in the fingerprint and the header). I'm not sure if this is an option you'd want to pursue, given that 

1. the problem is really with fingerprint-generator, and
2. `getUserAgent` exists already

The reason I didn't use `getUserAgent` is I assumed you stopped using it already for a good reason (no header is generated, or fingerprint-generator creates better fingerprints, etc.) so I didn't want to shoehorn it back in.