### PR TITLE
feat: update search settings and geo locale logic

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1,7 +1,7 @@
 {
     "baseURL": "https://rewards.bing.com",
     "sessionPath": "sessions",
-    "headless": false,
+    "headless": true,
     "runOnZeroPoints": false,
     "clusters": 1,
     "saveFingerprint": false,
@@ -16,7 +16,9 @@
     },
     "globalTimeout": 30000,
     "searchSettings": {
-        "useGeoLocaleQueries": true,
+        "useGeoLocaleQueries": false,
+        "defaultLang": "zh-CN",
+        "defaultGeo": "CN",
         "scrollRandomResults": true,
         "clickRandomResults": true,
         "searchDelay": {

--- a/src/functions/activities/ReadToEarn.ts
+++ b/src/functions/activities/ReadToEarn.ts
@@ -11,15 +11,13 @@ export class ReadToEarn extends Workers {
         this.bot.log('READ-TO-EARN', 'Starting Read to Earn')
 
         try {
-            let geoLocale = data.userProfile.attributes.country
-            geoLocale = (this.bot.config.searchSettings.useGeoLocaleQueries && geoLocale.length === 2) ? geoLocale.toLowerCase() : 'us'
-
+            const [, geo] = await this.bot.browser.func.getGeoLocale()
             const userDataRequest = {
                 url: 'https://prod.rewardsplatform.microsoft.com/dapi/me',
                 method: 'GET',
                 headers: {
                     'Authorization': `Bearer ${accessToken}`,
-                    'X-Rewards-Country': geoLocale,
+                    'X-Rewards-Country': geo.toLocaleLowerCase(),
                     'X-Rewards-Language': 'en'
                 }
             }
@@ -29,7 +27,7 @@ export class ReadToEarn extends Workers {
 
             const jsonData = {
                 amount: 1,
-                country: geoLocale,
+                country: geo.toLocaleLowerCase(),
                 id: '1',
                 type: 101,
                 attributes: {
@@ -46,7 +44,7 @@ export class ReadToEarn extends Workers {
                     headers: {
                         'Authorization': `Bearer ${accessToken}`,
                         'Content-Type': 'application/json',
-                        'X-Rewards-Country': geoLocale,
+                        'X-Rewards-Country': geo.toLocaleLowerCase(),
                         'X-Rewards-Language': 'en'
                     },
                     data: JSON.stringify(jsonData)

--- a/src/interface/Config.ts
+++ b/src/interface/Config.ts
@@ -13,6 +13,8 @@ export interface Config {
 
 export interface SearchSettings {
     useGeoLocaleQueries: boolean;
+    defaultLang: string;
+    defaultGeo: string;
     scrollRandomResults: boolean;
     clickRandomResults: boolean;
     searchDelay: SearchDelay;

--- a/src/interface/DailyTrends.ts
+++ b/src/interface/DailyTrends.ts
@@ -42,3 +42,27 @@ export interface Title {
     query: string;
     exploreLink: string;
 }
+
+export interface CNTrends {
+    code: number;
+    name: string;
+    title: string;
+    type: string;
+    link: string;
+    total: number;
+    updateTime: string;
+    fromCache: boolean;
+    data: TrendItem[];
+}
+
+export interface TrendItem {
+    id: number;
+    title: string;
+    desc: string;
+    cover: string;
+    author: string;
+    timestamp: string | null;
+    hot: number;
+    url: string;
+    mobileUrl: string;
+}

--- a/src/interface/Search.ts
+++ b/src/interface/Search.ts
@@ -2,3 +2,9 @@ export interface GoogleSearch {
     topic: string;
     related: string[];
 }
+
+export interface CNSearch {
+    title: string;
+}
+
+export type BingSearch = { GoogleSearch: GoogleSearch } | { CNSearch: CNSearch };


### PR DESCRIPTION
Since China cannot access Google, I added new search term sources for China.

And I found that my `data.userProfile.attributes.country` returned a null value. `"country": ""`,

So all I added was setting the geolocation based on the network ip, or setting `useGeoLocaleQuerie`s to `false` and using `defaultgeo`.

Tested 5 geos and found no obvious problems yet

```
[2024/10/4 22:07:39] [PID: 9176] [LOG] [SEARCH-TRENDS] Generating search queries, can take a while! | GeoLocale: 'CN'
Generated 30 search queries
[2024/10/4 22:07:41] [PID: 9176] [LOG] [SEARCH-BING] 30 Points Remaining | Query: 男孩骨折大哭听到不能写作业秒笑 | Mobile: false
[2024/10/4 22:08:19] [PID: 9176] [LOG] [SEARCH-BING] 27 Points Remaining | Query: 赵丽颖主演电影票房破50亿 | Mobile: false
[2024/10/4 22:08:49] [PID: 9176] [LOG] [SEARCH-BING] 24 Points Remaining | Query: 郑钦文晋级中网四强 | Mobile: false
[2024/10/4 22:09:22] [PID: 9176] [LOG] [SEARCH-BING] 21 Points Remaining | Query: 山西五台山排队上演真人版贪吃蛇 | Mobile: false
[2024/10/4 22:09:51] [PID: 9176] [LOG] [SEARCH-BING] 18 Points Remaining | Query: 多名大妈在机场休息厅开音响跳舞 | Mobile: false

[2024/10/4 22:11:52] [PID: 13460] [LOG] [SEARCH-GOOGLE-TRENDS] Generating search queries, can take a while! | GeoLocale: 'US'
Generated 20 search queries
[2024/10/4 22:11:55] [PID: 13460] [LOG] [SEARCH-BING] 15 Points Remaining | Query: kirk cousins | Mobile: false
[2024/10/4 22:12:30] [PID: 13460] [LOG] [SEARCH-BING] 12 Points Remaining | Query: tampa bay buccaneers vs atlanta falcons | Mobile: false
[2024/10/4 22:13:04] [PID: 13460] [LOG] [SEARCH-BING] 9 Points Remaining | Query: buccaneers vs falcons | Mobile: false
[2024/10/4 22:13:40] [PID: 13460] [LOG] [SEARCH-BING] 6 Points Remaining | Query: falcons | Mobile: false
[2024/10/4 22:14:13] [PID: 13460] [LOG] [SEARCH-BING] 3 Points Remaining | Query: atlanta falcons | Mobile: false

[2024/10/4 22:24:13] [PID: 16860] [LOG] [SEARCH-GOOGLE-TRENDS] Generating search queries, can take a while! | GeoLocale: 'JP'
Generated 36 search queries
[2024/10/4 22:24:17] [PID: 16860] [LOG] [SEARCH-BING] 36 Points Remaining | Query: アーセナル | Mobile: false
[2024/10/4 22:24:48] [PID: 16860] [LOG] [SEARCH-BING] 33 Points Remaining | Query: 豊臣兄弟 | Mobile: false
[2024/10/4 22:25:18] [PID: 16860] [LOG] [SEARCH-BING] 30 Points Remaining | Query: 大橋祐紀 | Mobile: false
[2024/10/4 22:25:49] [PID: 16860] [LOG] [SEARCH-BING] 27 Points Remaining | Query: 朝ドラ おむすび | Mobile: false
[2024/10/4 22:26:18] [PID: 16860] [LOG] [SEARCH-BING] 24 Points Remaining | Query: おむすび 朝ドラ | Mobile: false
[2024/10/4 22:26:55] [PID: 16860] [LOG] [SEARCH-BING] 21 Points Remaining | Query: 為替 | Mobile: false
[2024/10/4 22:27:26] [PID: 16860] [LOG] [SEARCH-BING] 18 Points Remaining | Query: 田中麗奈 | Mobile: false
[2024/10/4 22:27:56] [PID: 16860] [LOG] [SEARCH-BING] 15 Points Remaining | Query: ドル円 | Mobile: false
[2024/10/4 22:28:29] [PID: 16860] [LOG] [SEARCH-BING] 12 Points Remaining | Query: 為替 ドル円 | Mobile: false

[2024/10/4 22:32:16] [PID: 8348] [LOG] [SEARCH-GOOGLE-TRENDS] Generating search queries, can take a while! | GeoLocale: 'MX'
Generated 20 search queries
[2024/10/4 22:32:19] [PID: 8348] [LOG] [SEARCH-BING] 9 Points Remaining | Query: gob.mx/bienestar | Mobile: false
[2024/10/4 22:32:56] [PID: 8348] [LOG] [SEARCH-BING] 6 Points Remaining | Query: gob.mx bienestar | Mobile: false
[2024/10/4 22:33:34] [PID: 8348] [LOG] [SEARCH-BING] 3 Points Remaining | Query: pension mujeres bienestar | Mobile: false

[2024/10/4 22:39:24] [PID: 3776] [LOG] [SEARCH-GOOGLE-TRENDS] Generating search queries, can take a while! | GeoLocale: 'KR'
Generated 101 search queries
[2024/10/4 22:39:31] [PID: 3776] [LOG] [SEARCH-BING] 90 Points Remaining | Query: 홍명보 빵집 | Mobile: false
[2024/10/4 22:40:04] [PID: 3776] [LOG] [SEARCH-BING] 90 Points Remaining | Query: 천수정 | Mobile: false
[2024/10/4 22:40:37] [PID: 3776] [LOG] [SEARCH-BING] 90 Points Remaining | Query: 차서원 | Mobile: false
[2024/10/4 22:41:05] [PID: 3776] [LOG] [SEARCH-BING] 81 Points Remaining | Query: 경성크리처' 시즌2 | Mobile: false
```