### PR TITLE
Added french translations for the queries.json

### DIFF
--- a/src/functions/queries.json
+++ b/src/functions/queries.json
@@ -159,7 +159,7 @@
         ]
     },
     {
-        "title": "Traduisez n'importe quoi",
+        "title": "Traduisez tout",
         "queries": [
             "Traduisez bienvenue à la maison en coréen",
             "Traduisez bienvenue à la maison en japonais",
@@ -167,13 +167,13 @@
         ]
     },
     {
-        "title": "Recherchez les paroles d'une chanson",
+        "title": "Rechercher paroles de chanson",
         "queries": [
             "Paroles de Debarge rhythm of the night"
         ]
     },
     {
-        "title": "Regardons à nouveau ce film !",
+        "title": "Et si nous regardions ce film une nouvelle fois?",
         "queries": [
             "Alien film",
             "Film Aliens",
@@ -200,11 +200,11 @@
     {
         "title": "Vous pouvez suivre votre colis",
         "queries": [
-            "Suivi USPS"
+            "Suivi Chronopost"
         ]
     },
     {
-        "title": "Trouvez un endroit à découvrir",
+        "title": "Trouver un endroit à découvrir",
         "queries": [
             "Itinéraire vers Berlin",
             "Itinéraire vers Tokyo",
@@ -222,8 +222,8 @@
     {
         "title": "Convertissez rapidement votre argent",
         "queries": [
-            "convertir 250 USD en yen",
-            "convertir 500 USD en yen"
+            "convertir 250 EUR en yen",
+            "convertir 500 EUR en yen"
         ]
     },
     {
@@ -234,7 +234,7 @@
         ]
     },
     {
-        "title": "Trouvez des endroits où séjourner !",
+        "title": "Trouvez des emplacements pour rester!",
         "queries": [
             "Hôtels Berlin Allemagne",
             "Hôtels Amsterdam Pays-Bas"
@@ -243,13 +243,13 @@
     {
         "title": "Comment se porte l'économie ?",
         "queries": [
-            "sp 500"
+            "CAC 40"
         ]
     },
     {
         "title": "Qui a gagné ?",
         "queries": [
-            "score des Braves"
+            "score du Paris Saint-Germain"
         ]
     },
     {

--- a/src/functions/queries.json
+++ b/src/functions/queries.json
@@ -134,7 +134,7 @@
             "Japan time",
             "New York time"
         ]
-    }
+    },
 
     {
         "title": "Maisons près de chez vous",
@@ -271,7 +271,7 @@
             "Heure du Japon",
             "Heure de New York"
         ]
-    }
+    },
     {
         "title": "Vérifier la météo",
         "queries": [

--- a/src/functions/queries.json
+++ b/src/functions/queries.json
@@ -260,7 +260,7 @@
         ]
     },
     {
-        "title": "Élargissez votre vocabulaire",
+        "title": "Enrichissez votre vocabulaire",
         "queries": [
             "definition definition"
         ]

--- a/src/functions/queries.json
+++ b/src/functions/queries.json
@@ -161,9 +161,9 @@
     {
         "title": "Traduisez tout",
         "queries": [
-            "Traduisez bienvenue à la maison en coréen",
-            "Traduisez bienvenue à la maison en japonais",
-            "Traduisez au revoir en japonais"
+            "Traduction bienvenue à la maison en coréen",
+            "Traduction bienvenue à la maison en japonais",
+            "Traduction au revoir en japonais"
         ]
     },
     {

--- a/src/functions/queries.json
+++ b/src/functions/queries.json
@@ -159,7 +159,7 @@
         ]
     },
     {
-        "title": "Traduisez tout",
+        "title": "Traduisez tout !",
         "queries": [
             "Traduction bienvenue à la maison en coréen",
             "Traduction bienvenue à la maison en japonais",

--- a/src/functions/queries.json
+++ b/src/functions/queries.json
@@ -204,7 +204,7 @@
         ]
     },
     {
-        "title": "Trouvez un nouvel endroit à explorer",
+        "title": "Trouvez un endroit à découvrir",
         "queries": [
             "Itinéraire vers Berlin",
             "Itinéraire vers Tokyo",

--- a/src/functions/queries.json
+++ b/src/functions/queries.json
@@ -182,14 +182,14 @@
         ]
     },
     {
-        "title": "Planifiez une escapade rapide",
+        "title": "Planifiez une petite escapade",
         "queries": [
             "Vols Amsterdam-Tokyo",
             "Vols New York-Tokyo"
         ]
     },
     {
-        "title": "Découvrez les postes vacants",
+        "title": "Consulter postes à pourvoir",
         "queries": [
             "emplois chez Microsoft",
             "Offres d'emploi Microsoft",
@@ -277,6 +277,13 @@
         "queries": [
             "Météo de Paris",
             "Météo de la France"
+        ]
+    },
+    {
+        "title": "Tenez-vous informé des sujets d'actualité",
+        "queries": [
+            "Augmentation Impots",
+            "Mort célébrité"
         ]
     }
 ]

--- a/src/functions/queries.json
+++ b/src/functions/queries.json
@@ -135,4 +135,148 @@
             "New York time"
         ]
     }
+
+    {
+        "title": "Maisons près de chez vous",
+        "queries": [
+            "Maisons près de chez moi"
+        ]
+    },
+    {
+        "title": "Vous ressentez des symptômes ?",
+        "queries": [
+            "Éruption cutanée sur l'avant-bras",
+            "Nez bouché",
+            "Toux chatouilleuse"
+        ]
+    },
+    {
+        "title": "Faites vos achats plus vite",
+        "queries": [
+            "Acheter une PS5",
+            "Acheter une Xbox",
+            "Offres sur les chaises"
+        ]
+    },
+    {
+        "title": "Traduisez n'importe quoi",
+        "queries": [
+            "Traduisez bienvenue à la maison en coréen",
+            "Traduisez bienvenue à la maison en japonais",
+            "Traduisez au revoir en japonais"
+        ]
+    },
+    {
+        "title": "Recherchez les paroles d'une chanson",
+        "queries": [
+            "Paroles de Debarge rhythm of the night"
+        ]
+    },
+    {
+        "title": "Regardons à nouveau ce film !",
+        "queries": [
+            "Alien film",
+            "Film Aliens",
+            "Film Alien 3",
+            "Film Predator"
+        ]
+    },
+    {
+        "title": "Planifiez une escapade rapide",
+        "queries": [
+            "Vols Amsterdam-Tokyo",
+            "Vols New York-Tokyo"
+        ]
+    },
+    {
+        "title": "Découvrez les postes vacants",
+        "queries": [
+            "emplois chez Microsoft",
+            "Offres d'emploi Microsoft",
+            "Emplois près de chez moi",
+            "emplois chez Boeing"
+        ]
+    },
+    {
+        "title": "Vous pouvez suivre votre colis",
+        "queries": [
+            "Suivi USPS"
+        ]
+    },
+    {
+        "title": "Trouvez un nouvel endroit à explorer",
+        "queries": [
+            "Itinéraire vers Berlin",
+            "Itinéraire vers Tokyo",
+            "Itinéraire vers New York"
+        ]
+    },
+    {
+        "title": "Trop fatigué pour cuisiner ce soir ?",
+        "queries": [
+            "KFC près de chez moi",
+            "Burger King près de chez moi",
+            "McDonalds près de chez moi"
+        ]
+    },
+    {
+        "title": "Convertissez rapidement votre argent",
+        "queries": [
+            "convertir 250 USD en yen",
+            "convertir 500 USD en yen"
+        ]
+    },
+    {
+        "title": "Apprenez à cuisiner une nouvelle recette",
+        "queries": [
+            "Comment faire cuire la ratatouille",
+            "Comment faire cuire les lasagnes"
+        ]
+    },
+    {
+        "title": "Trouvez des endroits où séjourner !",
+        "queries": [
+            "Hôtels Berlin Allemagne",
+            "Hôtels Amsterdam Pays-Bas"
+        ]
+    },
+    {
+        "title": "Comment se porte l'économie ?",
+        "queries": [
+            "sp 500"
+        ]
+    },
+    {
+        "title": "Qui a gagné ?",
+        "queries": [
+            "score des Braves"
+        ]
+    },
+    {
+        "title": "Temps de jeu",
+        "queries": [
+            "Jeu vidéo Overwatch",
+            "Jeu vidéo Call of Duty"
+        ]
+    },
+    {
+        "title": "Élargissez votre vocabulaire",
+        "queries": [
+            "definition definition"
+        ]
+    },
+    {
+        "title": "Quelle heure est-il ?",
+        "queries": [
+            "Heure du Japon",
+            "Heure de New York"
+        ]
+    }
+    {
+        "title": "Vérifier la météo",
+        "queries": [
+            "Météo de Paris",
+            "Météo de la France"
+        ]
+    }
 ]


### PR DESCRIPTION
The queries were made for the english version of microsoft reward, but not for other languages, so if the activities are in another language, then it won't detect them.
I inputted the queries into google translation and put them back here, and ajusted the ones i knew to match the activities name. I did the ones i could today, i will update the pull request in the next few days with the ones that i can get (i got a ban wave, most of my accounts got randomly banned, so i'm cautious around this for now)
I also got a new search name about the meteo that wasn't in the english version (see the last one), so you might wanna check that out
