### PR TITLE
Use pre-build and simplify dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,22 +17,17 @@ RUN apt-get update && apt-get install -y \
     libatk-bridge2.0-0 \
     libgtk-3-0 \
     tzdata \
+    wget \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy all files to the working directory
 COPY . .
 
-# Install application dependencies
+# Install dependencies, set permissions, and build the script
 RUN npm install && \
-    # Ensure correct permissions for node_modules
     chmod -R 755 /usr/src/microsoft-rewards-script/node_modules && \
-    # Install Playwright Chromium directly from local node_modules
-    ./node_modules/.bin/playwright install chromium --with-deps && \
-    # Ensure correct permissions for the working directory
-    chmod -R 755 /usr/src/microsoft-rewards-script
-
-# Build the TypeScript project
-RUN npm run build
+    npm run pre-build && \
+    npm run build
 
 # Copy cron file to cron directory
 COPY src/crontab.template /etc/cron.d/microsoft-rewards-cron.template


### PR DESCRIPTION
This is a **non-urgent update** to the dockerfile that uses the new pre-build script in package.json to handle installing all the deps, greatly simplifying the dockerfile. 

The dockerfile in the original PR should still work with playwrights locked in package.json. This PR just tidies up the dockerfile further based on the recent updates/changes.