### PR TITLE
Experimental push notification support (via NTFY)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,7 @@ Under development, however mainly for personal use!
 
 2. **Update `accounts.json`**
 
-3. **Edit `config.json`,** ensuring the following values are set (other settings are up to your preference):
-
-   ```json
-   "headless": true,
-   "clusters": 1,
-   ```
+3. **Edit `config.json`,** ensuring `   "headless": true,`. Other settings are up to your preference.
 
 ### **Customize the `compose.yaml` File**
 
@@ -78,6 +73,27 @@ A basic docker `compose.yaml` is provided. Follow these steps to configure and r
 | cronStartTime | Scheduled script run-time, *only available for docker implementation* | `0 5,11 * * *` (5:00 am, 11:00 am daily) |
 |  | Run the script immediately when the Docker container starts | `true` |
 
+
+## NTFY push notifications (experimental) ##
+Push notification can be optionally enabled using [NTFY](https://ntfy.sh/). 
+
+1. Open config.json and locate the ntfy section.
+2. Set "enabled" to true
+3. Add your NTFY server URL in the "url" field.
+4. Enter the topic for notifications in the "topic" field.
+5. Optionally, add your NTFY authentication token in the "authToken" field (if required).
+6. Save the file.
+7. Rebuild the script or recreate the docker container if it's already running to apply the changes.
+
+### Notification customizations ###
+- To change the emojis used in the notifications, edit the tags in `Ntfy.sh`. Visit NTFY's emoji customization [guide](https://docs.ntfy.sh/emojis) for available options.
+- To customize which keywords trigger notifications, edit the keywords in `Logger.ts`.
+- By default, notifications will be sent for the following events, per account:
+  - Script start
+  - 2FA/passwordless codes
+  - Script completion
+  - Critical warnings
+
 ## Features ##
 - [x] Multi-Account Support
 - [x] Session Storing
@@ -107,6 +123,7 @@ A basic docker `compose.yaml` is provided. Follow these steps to configure and r
 - [x] Proxy Support
 - [x] Docker Support (experimental)
 - [x] Automatic scheduling (via Docker)
+- [x] Push notifications (via NTFY)
 
 ## Disclaimer ##
 Your account may be at risk of getting banned or suspended using this script, you've been warned!

--- a/src/config.json
+++ b/src/config.json
@@ -33,5 +33,11 @@
     "webhook": {
         "enabled": false,
         "url": ""
+    },
+    "ntfy": {
+        "enabled": false,
+        "url": "",  
+        "topic": "", 
+        "authToken": "" 
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,7 +132,7 @@ export class MicrosoftRewardsBot {
                 await this.Mobile(account)
             }
 
-            log('main', 'MAIN-WORKER', `Completed tasks for account ${account.email}`, 'log', 'green')
+            await log('main', 'MAIN-WORKER', `Completed tasks for account ${account.email}`, 'log', 'green')
         }
 
         await log(this.isMobile, 'MAIN-PRIMARY', 'Completed tasks for ALL accounts', 'log', 'green')

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,7 +135,7 @@ export class MicrosoftRewardsBot {
             log('main', 'MAIN-WORKER', `Completed tasks for account ${account.email}`, 'log', 'green')
         }
 
-        log(this.isMobile, 'MAIN-PRIMARY', 'Completed tasks for ALL accounts', 'log', 'green')
+        await(this.isMobile, 'MAIN-PRIMARY', 'Completed tasks for ALL accounts', 'log', 'green')
         process.exit()
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,7 +135,7 @@ export class MicrosoftRewardsBot {
             log('main', 'MAIN-WORKER', `Completed tasks for account ${account.email}`, 'log', 'green')
         }
 
-        await(this.isMobile, 'MAIN-PRIMARY', 'Completed tasks for ALL accounts', 'log', 'green')
+        await log(this.isMobile, 'MAIN-PRIMARY', 'Completed tasks for ALL accounts', 'log', 'green')
         process.exit()
     }
 

--- a/src/interface/Config.ts
+++ b/src/interface/Config.ts
@@ -10,7 +10,15 @@ export interface Config {
     globalTimeout: number | string;
     searchSettings: SearchSettings;
     webhook: Webhook;
+    ntfy: Ntfy;  // <-- Added Ntfy configuration
     saveFingerprint: ConfigSaveFingerprint;
+}
+
+export interface Ntfy {
+    enabled: boolean;
+    url: string;
+    topic: string;
+    authToken?: string; // Optional authentication token
 }
 
 export interface ConfigSaveFingerprint {

--- a/src/util/Logger.ts
+++ b/src/util/Logger.ts
@@ -18,6 +18,7 @@ export async function log(isMobile: boolean | 'main', title: string, message: st
         log: [
             message.toLowerCase().includes('started tasks for account'),
             message.toLowerCase().includes('press the number'),
+            message.toLowerCase().includes('this script collected'),
             message.toLowerCase().includes('completed tasks for account')
         ], // Add or customize keywords for log messages here
         error: [], // Add or customize keywords for error messages here

--- a/src/util/Logger.ts
+++ b/src/util/Logger.ts
@@ -18,7 +18,7 @@ export async function log(isMobile: boolean | 'main', title: string, message: st
         log: [
             message.toLowerCase().includes('started tasks for account'),
             message.toLowerCase().includes('press the number'),
-            message.toLowerCase().includes('this script collected'),
+            message.toLowerCase().includes('the script collected'),
             message.toLowerCase().includes('completed tasks for account')
         ], // Add or customize keywords for log messages here
         error: [], // Add or customize keywords for error messages here

--- a/src/util/Logger.ts
+++ b/src/util/Logger.ts
@@ -1,35 +1,40 @@
-import chalk from 'chalk'
-
-import { Webhook } from './Webhook'
+import chalk from 'chalk';
+import { Webhook } from './Webhook';
+import { Ntfy } from './Ntfy';
 
 export function log(isMobile: boolean | 'main', title: string, message: string, type: 'log' | 'warn' | 'error' = 'log', color?: keyof typeof chalk): void {
-    const currentTime = new Date().toLocaleString()
-    const platformText = isMobile === 'main' ? 'MAIN' : isMobile ? 'MOBILE' : 'DESKTOP'
-    const chalkedPlatform = isMobile === 'main' ? chalk.bgCyan('MAIN') : isMobile ? chalk.bgBlue('MOBILE') : chalk.bgMagenta('DESKTOP')
+    const currentTime = new Date().toLocaleString();
+    const platformText = isMobile === 'main' ? 'MAIN' : isMobile ? 'MOBILE' : 'DESKTOP';
+    const chalkedPlatform = isMobile === 'main' ? chalk.bgCyan('MAIN') : isMobile ? chalk.bgBlue('MOBILE') : chalk.bgMagenta('DESKTOP');
 
-    // Clean string for the Webhook (no chalk)
-    const cleanStr = `[${currentTime}] [PID: ${process.pid}] [${type.toUpperCase()}] ${platformText} [${title}] ${message}`
+    // Clean string for Webhook and NTFY (no chalk formatting)
+    const cleanStr = `[${currentTime}] [PID: ${process.pid}] [${type.toUpperCase()}] ${platformText} [${title}] ${message}`;
 
-    // Send the clean string to the Webhook
-    Webhook(cleanStr)
+    // Send to Webhook if enabled
+    Webhook(cleanStr);
+
+    // Send to NTFY only for specific logs
+    if (type === 'warn' || type === 'error' || message.toLowerCase().includes('completed') || message.includes('2FA')) {
+        Ntfy(cleanStr);
+    }
 
     // Formatted string with chalk for terminal logging
-    const str = `[${currentTime}] [PID: ${process.pid}] [${type.toUpperCase()}] ${chalkedPlatform} [${title}] ${message}`
+    const str = `[${currentTime}] [PID: ${process.pid}] [${type.toUpperCase()}] ${chalkedPlatform} [${title}] ${message}`;
 
-    const applyChalk = color && typeof chalk[color] === 'function' ? chalk[color] as (msg: string) => string : null
+    const applyChalk = color && typeof chalk[color] === 'function' ? chalk[color] as (msg: string) => string : null;
 
-    // Log based on the type
+    // Log based on type
     switch (type) {
         case 'warn':
-            applyChalk ? console.warn(applyChalk(str)) : console.warn(str)
-            break
+            applyChalk ? console.warn(applyChalk(str)) : console.warn(str);
+            break;
 
         case 'error':
-            applyChalk ? console.error(applyChalk(str)) : console.error(str)
-            break
+            applyChalk ? console.error(applyChalk(str)) : console.error(str);
+            break;
 
         default:
-            applyChalk ? console.log(applyChalk(str)) : console.log(str)
-            break
+            applyChalk ? console.log(applyChalk(str)) : console.log(str);
+            break;
     }
 }

--- a/src/util/Logger.ts
+++ b/src/util/Logger.ts
@@ -14,7 +14,10 @@ export function log(isMobile: boolean | 'main', title: string, message: string, 
     Webhook(cleanStr);
 
     // Send to NTFY only for specific logs
-    if (type === 'warn' || type === 'error' || message.toLowerCase().includes('completed') || message.includes('2FA')) {
+    if (type === 'warn' || type === 'error' || 
+        message.toLowerCase().includes('completed tasks for') || 
+        message.toLowerCase().includes('press the number') || 
+        message.includes('2FA')) {
         Ntfy(cleanStr);
     }
 

--- a/src/util/Logger.ts
+++ b/src/util/Logger.ts
@@ -13,14 +13,15 @@ export function log(isMobile: boolean | 'main', title: string, message: string, 
     // Send to Webhook if enabled
     Webhook(cleanStr);
 
-    // Send to NTFY only for specific logs
-    if (type === 'warn' || type === 'error' || 
-        message.toLowerCase().includes('completed tasks for') || 
-        message.toLowerCase().includes('press the number') || 
-        message.includes('2FA')) {
-        Ntfy(cleanStr);
+    // Send only specific log messages to NTFY
+    if (
+        (type === 'log' && (message.toLowerCase().includes('completed tasks for') || message.toLowerCase().includes('press the number')))
+        || (type === 'error' && message.toLowerCase().includes('ending'))
+        || (type === 'warn' && (message.toLowerCase().includes('aborting') || message.toLowerCase().includes("didn't gain")))
+    ) {
+        Ntfy(cleanStr, type);
     }
-
+    
     // Formatted string with chalk for terminal logging
     const str = `[${currentTime}] [PID: ${process.pid}] [${type.toUpperCase()}] ${chalkedPlatform} [${title}] ${message}`;
 

--- a/src/util/Ntfy.ts
+++ b/src/util/Ntfy.ts
@@ -1,0 +1,21 @@
+import axios from 'axios';
+import { loadConfig } from './Load';
+
+export async function Ntfy(content: string) {
+    const config = loadConfig();
+    const ntfy = config.ntfy;
+
+    if (!ntfy.enabled || ntfy.url.length < 10 || !ntfy.topic) return;
+
+    const request = {
+        method: 'POST',
+        url: `${ntfy.url}/${ntfy.topic}`, // Sends to the correct topic
+        headers: {
+            'Content-Type': 'text/plain',
+            'Authorization': `Bearer ${ntfy.authToken}` // If authToken is required
+        },
+        data: content
+    };
+
+    await axios(request).catch((err) => console.error("NTFY Error:", err));
+}

--- a/src/util/Webhook.ts
+++ b/src/util/Webhook.ts
@@ -1,9 +1,7 @@
 import axios from 'axios'
-
 import { loadConfig } from './Load'
 
-
-export async function Webhook(content: string) {
+export function Webhook(content: string) {
     const webhook = loadConfig().webhook
 
     if (!webhook.enabled || webhook.url.length < 10) return
@@ -19,5 +17,5 @@ export async function Webhook(content: string) {
         }
     }
 
-    await axios(request).catch(() => { })
+    return axios(request).catch(() => { })
 }


### PR DESCRIPTION
This PR adds experimental push notification support via [NTFY](https://ntfy.sh/), closing FR #90 

Summary of changes:
- users input NTFY server, topic, and optionally auth in the `config.json`, parsed using `Config.ts`
- `Logger.ts` matches [LOG], [ERROR], and [WARN] against customizable key words to generate notifications (with comments added to show where such customization can occur)
- `Ntfy.sh` sends customizable notifications using `Axios.ts`, which include emojis and prioritization based on type (e.g., high priority for warnings).
-  `Readme` updated to briefly describe setup, and customization options. 

By default, notifications are sent for each account: script started, 2FA/passwordless code, script successfully completed, and major warnings (e.g., searches not completed).

Huge thanks to @AariaX for fixing axios support for sending.