### PR TITLE
fix: don't retry search on 0

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -272,7 +272,7 @@ export class MicrosoftRewardsBot {
                 // Exit if retries are exhausted
                 if (this.mobileRetryAttempts > this.config.searchSettings.retryMobileSearchAmount) {
                     log(this.isMobile, 'MAIN', `Max retry limit of ${this.config.searchSettings.retryMobileSearchAmount} reached. Exiting retry loop`, 'warn')
-                } else {
+                } else if (this.mobileRetryAttempts !== 0) {
                     log(this.isMobile, 'MAIN', `Attempt ${this.mobileRetryAttempts}/${this.config.searchSettings.retryMobileSearchAmount}: Unable to complete mobile searches, bad User-Agent? Increase search delay? Retrying...`, 'log', 'yellow')
 
                     // Close mobile browser


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/76105362-20e5-4414-b2bb-a823780dfeae)

According to line 270 retry shouldn't be 0 if failed to complete search?