### PR TITLE
Docker rewrite and optimizations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Use the official Playwright image matching your Playwright version
+# Use the official Playwright image matching the Script Playwright version
 FROM mcr.microsoft.com/playwright:v1.47.2-jammy
 
 # Set working directory inside the container
@@ -18,16 +18,11 @@ COPY . .
 # Run pre-build script (installs playwright browsers, cleans dist) and build TypeScript
 RUN npm run pre-build && npm run build
 
-# Ensure sessions directory exists to avoid runtime errors
-RUN mkdir -p /usr/src/microsoft-rewards-script/dist/browser/sessions
-
 # Copy cron job template to the appropriate location
 COPY src/crontab.template /etc/cron.d/microsoft-rewards-cron.template
 
 # Create cron log file and set permissions so cron can write to it
 RUN touch /var/log/cron.log && chmod 666 /var/log/cron.log
-
-# Removed USER pwuser to run as root
 
 # Set default command:
 # - Configure timezone inside container based on $TZ environment variable

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,48 +1,73 @@
-# Use the official Playwright image matching the Script Playwright version
-FROM mcr.microsoft.com/playwright:v1.47.2-jammy
+###############################################################################
+# Stage 1: Builder (compile TypeScript)
+###############################################################################
+FROM node:18-slim AS builder
 
-# Set working directory inside the container
 WORKDIR /usr/src/microsoft-rewards-script
 
-# Install runtime dependencies
-RUN apt-get update && \
-    apt-get install -y cron gettext-base && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+# Install minimal tooling if needed
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 
-# Copy package.json and package-lock.json (if it exists) to leverage Docker cache
+# Copy package manifests
 COPY package*.json ./
 
-# Install dependencies:
-# - Use `npm ci` if package-lock.json exists for clean install
-# - Otherwise, fallback to `npm install`
-RUN if [ -f package-lock.json ]; then npm ci; else npm install; fi
+# Conditional install: npm ci if lockfile exists, else npm install
+RUN if [ -f package-lock.json ]; then \
+      npm ci; \
+    else \
+      npm install; \
+    fi
 
-# Copy the rest of the source code into the container
+# Copy source code
 COPY . .
 
-# Ensure the cron script is executable
-# Run pre-build script (installs playwright browsers, cleans dist) and build TypeScript
-RUN chmod +x ./src/run_daily.sh && \
-    npm run pre-build && npm run build
+# Build TypeScript
+RUN npx rimraf dist \
+    && npm run build
 
-# Copy cron job template to the appropriate location
+###############################################################################
+# Stage 2: Runtime (Playwright image)
+###############################################################################
+FROM mcr.microsoft.com/playwright:v1.52.0-jammy
+
+WORKDIR /usr/src/microsoft-rewards-script
+
+# Install cron, gettext-base (for envsubst), tzdata noninteractively
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+         cron gettext-base tzdata \
+    && rm -rf /var/lib/apt/lists/*
+
+# Ensure Playwright uses preinstalled browsers
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+
+# Copy built artifacts and package.json
+COPY --from=builder /usr/src/microsoft-rewards-script/dist ./dist
+COPY --from=builder /usr/src/microsoft-rewards-script/package*.json ./
+
+# Install only production dependencies, with fallback
+RUN if [ -f package-lock.json ]; then \
+      npm ci --omit=dev; \
+    else \
+      npm install --production; \
+    fi
+
+# Copy automation script and cron template
+COPY src/run_daily.sh ./src/run_daily.sh
+RUN chmod +x ./src/run_daily.sh
 COPY src/crontab.template /etc/cron.d/microsoft-rewards-cron.template
 
-# Create cron log file and set permissions so cron can write to it
-RUN touch /var/log/cron.log && chmod 666 /var/log/cron.log
+# Copy entrypoint and make executable
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
 
-# Set default command:
-# - Configure timezone inside container based on $TZ environment variable
-# - Set up cron job from template with environment substitution
-# - Start cron in foreground
-# - Optionally start the script immediately if RUN_ON_START=true
-# - Tail cron log to keep container running and output logs
-CMD ["sh", "-c", "\
-    ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
-    echo \"$TZ\" > /etc/timezone && \
-    envsubst < /etc/cron.d/microsoft-rewards-cron.template > /etc/cron.d/microsoft-rewards-cron && \
-    chmod 0644 /etc/cron.d/microsoft-rewards-cron && \
-    crontab /etc/cron.d/microsoft-rewards-cron && \
-    cron -f & \
-    ([ \"$RUN_ON_START\" = \"true\" ] && npm start); \
-    tail -f /var/log/cron.log"]
+# Default TZ (overridden by user via environment)
+ENV TZ=UTC
+
+# Entrypoint handles TZ, initial run toggle, cron templating & launch
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+
+# CMD is a no-op since ENTRYPOINT execs cron; left for clarity
+CMD ["sh", "-c", "echo 'Container started; cron is running.'"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,47 +1,46 @@
-# Use an official Node.js runtime as a base image
-FROM node:18
+# Use the official Playwright image matching your Playwright version
+FROM mcr.microsoft.com/playwright:v1.47.2-jammy
 
-# Set the working directory in the container
+# Set working directory inside the container
 WORKDIR /usr/src/microsoft-rewards-script
 
-# Install necessary dependencies for Playwright and cron
-RUN apt-get update && apt-get install -y \
-    jq \
-    cron \
-    gettext-base \
-    xvfb \
-    libgbm-dev \
-    libnss3 \
-    libasound2 \
-    libxss1 \
-    libatk-bridge2.0-0 \
-    libgtk-3-0 \
-    tzdata \
-    wget \
-    && rm -rf /var/lib/apt/lists/*
+# Copy package.json and package-lock.json (if it exists) to leverage Docker cache
+COPY package*.json ./
 
-# Copy all files to the working directory
+# Install dependencies:
+# - Use `npm ci` if package-lock.json exists for clean install
+# - Otherwise, fallback to `npm install`
+RUN if [ -f package-lock.json ]; then npm ci; else npm install; fi
+
+# Copy the rest of the source code into the container
 COPY . .
 
-# Install dependencies, set permissions, and build the script
-RUN npm install && \
-    chmod -R 755 /usr/src/microsoft-rewards-script/node_modules && \
-    npm run pre-build && \
-    npm run build
+# Run pre-build script (installs playwright browsers, cleans dist) and build TypeScript
+RUN npm run pre-build && npm run build
 
-# Copy cron file to cron directory
+# Ensure sessions directory exists to avoid runtime errors
+RUN mkdir -p /usr/src/microsoft-rewards-script/dist/browser/sessions
+
+# Copy cron job template to the appropriate location
 COPY src/crontab.template /etc/cron.d/microsoft-rewards-cron.template
 
-# Create the log file to be able to run tail
-RUN touch /var/log/cron.log
+# Create cron log file and set permissions so cron can write to it
+RUN touch /var/log/cron.log && chmod 666 /var/log/cron.log
 
-# Define the command to run your application with cron optionally
-CMD ["sh", "-c", "echo \"$TZ\" > /etc/timezone && \
+# Removed USER pwuser to run as root
+
+# Set default command:
+# - Configure timezone inside container based on $TZ environment variable
+# - Set up cron job from template with environment substitution
+# - Start cron in foreground
+# - Optionally start the script immediately if RUN_ON_START=true
+# - Tail cron log to keep container running and output logs
+CMD ["sh", "-c", "\
     ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
-    dpkg-reconfigure -f noninteractive tzdata && \
+    echo \"$TZ\" > /etc/timezone && \
     envsubst < /etc/cron.d/microsoft-rewards-cron.template > /etc/cron.d/microsoft-rewards-cron && \
     chmod 0644 /etc/cron.d/microsoft-rewards-cron && \
     crontab /etc/cron.d/microsoft-rewards-cron && \
     cron -f & \
-    ([ \"$RUN_ON_START\" = \"true\" ] && npm start) && \
+    ([ \"$RUN_ON_START\" = \"true\" ] && npm start); \
     tail -f /var/log/cron.log"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -16,6 +16,24 @@ services:
       CRON_SCHEDULE: "0 7,16,20 * * *" # Customize your schedule, use crontab.guru for formatting
       RUN_ON_START: "true" # Runs the script on container startup
 
-    # Optional resource limits for standalone Compose
-    mem_limit: 5g
-    cpus: 2.5
+      # Start-time randomization (uncomment to customize or disable)
+      #MIN_SLEEP_MINUTES: "5"
+      #MAX_SLEEP_MINUTES: "50"
+      SKIP_RANDOM_SLEEP: "false"
+
+    # Optional resource limits for the container
+    mem_limit: 4g
+    cpus: 2
+
+    # Health check - monitors if cron daemon is running to ensure scheduled jobs can execute
+    # Container marked unhealthy if cron process dies
+    healthcheck:
+      test: ["CMD", "sh", "-c", "pgrep cron > /dev/null || exit 1"]
+      interval: 60s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    
+    # Security hardening
+    security_opt:
+      - no-new-privileges:true

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,15 +1,21 @@
 services:
-  microsoft-rewards-script:
+  netsky:
     build: .
     container_name: microsoft-rewards-script
     restart: unless-stopped
+
+    # Volume mounts: Specify a location where you want to save the files on your local machine.
     volumes:
-      ### Replace "/path/to/" with the actual path to where you want to save the files on your local machine.
-      - /path/to/accounts.json:/usr/src/microsoft-rewards-script/dist/accounts.json
-      - /path/to/config.json:/usr/src/microsoft-rewards-script/dist/config.json 
-      - /path/to/sessions:/usr/src/microsoft-rewards-script/dist/browser/sessions # Optional, saves your login session
+      - ./src/accounts.json:/usr/src/microsoft-rewards-script/dist/accounts.json:ro
+      - ./src/config.json:/usr/src/microsoft-rewards-script/dist/config.json:ro
+      - ./sessions:/usr/src/microsoft-rewards-script/dist/browser/sessions # Optional, saves your login session
+
     environment:
-      - NODE_ENV=production
-      - CRON_SCHEDULE=0 7,15,20 * * * # Customize your schedule, use crontab.guru for formatting
-      - RUN_ON_START=true # Runs the script on container startup
-      - TZ=America/Toronto # Set your timezone for proper scheduling
+      TZ: "America/Toronto" # Set your timezone for proper scheduling
+      NODE_ENV: "production"
+      CRON_SCHEDULE: "0 7,16,20 * * *" # Customize your schedule, use crontab.guru for formatting
+      RUN_ON_START: "true" # Runs the script on container startup
+
+    # Optional resource limits for standalone Compose
+    mem_limit: 5g
+    cpus: 2.5

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env sh
+set -eu
+
+# Ensure Playwright uses preinstalled browsers
+export PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+
+# 1. Timezone: default to UTC if not provided
+: "${TZ:=UTC}"
+ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime
+echo "$TZ" > /etc/timezone
+
+# 2. Validate CRON_SCHEDULE
+if [ -z "${CRON_SCHEDULE:-}" ]; then
+  echo "ERROR: CRON_SCHEDULE environment variable is not set." >&2
+  echo "Please set CRON_SCHEDULE (e.g., \"0 2 * * *\")." >&2
+  exit 1
+fi
+
+# 3. Initial run without sleep if RUN_ON_START=true
+if [ "${RUN_ON_START:-false}" = "true" ]; then
+  echo "[entrypoint] RUN_ON_START=true: performing initial run at $(date -Is)"
+  cd /usr/src/microsoft-rewards-script || {
+    echo "[entrypoint] ERROR: Unable to cd to /usr/src/microsoft-rewards-script" >&2
+    # proceed to cron setup so scheduled runs still occur
+  }
+  # npm start will pick up PLAYWRIGHT_BROWSERS_PATH from environment
+  if ! npm start; then
+    echo "[entrypoint] WARNING: Initial run failed; continuing to cron for future runs" >&2
+  else
+    echo "[entrypoint] Initial run completed successfully at $(date -Is)"
+  fi
+fi
+
+# 4. Template and register cron file
+if [ ! -f /etc/cron.d/microsoft-rewards-cron.template ]; then
+  echo "ERROR: Cron template /etc/cron.d/microsoft-rewards-cron.template not found." >&2
+  exit 1
+fi
+envsubst < /etc/cron.d/microsoft-rewards-cron.template > /etc/cron.d/microsoft-rewards-cron
+chmod 0644 /etc/cron.d/microsoft-rewards-cron
+crontab /etc/cron.d/microsoft-rewards-cron
+
+echo "[entrypoint] Cron configured with schedule: $CRON_SCHEDULE; starting cron at $(date -Is)"
+
+# 5. Start cron in foreground (PID 1)
+exec cron -f

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "http-proxy-agent": "^7.0.2",
     "https-proxy-agent": "^7.0.6",
     "ms": "^2.1.3",
-    "playwright": "1.47.2",
-    "rebrowser-playwright": "1.47.2",
+    "playwright": "1.52.0",
+    "rebrowser-playwright": "1.52.0",
     "socks-proxy-agent": "^8.0.5",
     "ts-node": "^10.9.2"
   }

--- a/src/crontab.template
+++ b/src/crontab.template
@@ -1,2 +1,2 @@
 # Run automation according to CRON_SCHEDULE; redirect both stdout & stderr to Docker logs
-${CRON_SCHEDULE} TZ=${TZ:-UTC} /bin/bash /usr/src/microsoft-rewards-script/src/run_daily.sh >> /proc/1/fd/1 2>&1
+${CRON_SCHEDULE} TZ=${TZ} /bin/bash /usr/src/microsoft-rewards-script/src/run_daily.sh >> /proc/1/fd/1 2>&1

--- a/src/crontab.template
+++ b/src/crontab.template
@@ -1,1 +1,2 @@
-${CRON_SCHEDULE} TZ=${TZ} /bin/bash /usr/src/microsoft-rewards-script/src/run_daily.sh >> /proc/1/fd/1 2>> /proc/1/fd/2
+# Run automation according to CRON_SCHEDULE; redirect both stdout & stderr to Docker logs
+${CRON_SCHEDULE} TZ=${TZ:-UTC} /bin/bash /usr/src/microsoft-rewards-script/src/run_daily.sh >> /proc/1/fd/1 2>&1


### PR DESCRIPTION
I took some time to fairly significantly rewrite the docker implementation, summary:

- Rewrote Dockerfile as a multi-stage build (builder + runtime) for smaller, more secure images. It builds the script in stage 1, then runs the script in stage 2. The idea being that we don't need to keep all the building components around in the container once the script is actually built, just the minimal stuff to run it. This is my attempt to do so. 
- Added entrypoint.sh to set timezone, validate CRON_SCHEDULE, and optionally run script immediately on container start with better logic and logging. This replaces trying to do it all in the CMD of the Dockerfile, which was getting messy. Simpler to maintain.
- Improved run_daily.sh: added flock locking so that the script won't automatically begin a scheduled start if the script is currently running (prevent overlapping runs), added logic to customize my sleep/start-time randomization (see compose.yaml), enhanced logging.
- Updated cron template and improved cron and timezone logging (use `docker logs microsoft-rewards-script`)
- Updated Playwright to v1.52.0 in Dockerfile and package.json.
- Compose (sample): added optional customizations for sleep randomization, optional container health monitoring, and optional resource limits

> note re sleep randomization: I've always had this in the docker implementation of the script, it's some brief logic to add +n random minutes to each cron scheduled run so it's not the exact same time each day. What I added here was the ability to enable/disable/customize this randomization along with the other changes above. 

> note re dockerfile: if there's an update to the version in package.json, it must also be updated to match in the dockerfile. 