### PR TITLE
fix skip 2FA

### DIFF
--- a/src/functions/Login.ts
+++ b/src/functions/Login.ts
@@ -128,9 +128,19 @@ export class Login {
 
     private async enterPassword(page: Page, password: string) {
         const passwordInputSelector = 'input[type="password"]'
+        const skip2FASelector = '#idA_PWD_SwitchToPassword';
         try {
-            const viewFooter = await page.waitForSelector('[data-testid="viewFooter"]', { timeout: 2000 }).catch(() => null)
-            if (viewFooter) {
+            const skip2FAButton = await page.waitForSelector(skip2FASelector, { timeout: 2000 }).catch(() => null)
+            if (skip2FAButton) {
+                await skip2FAButton.click()
+                await this.bot.utils.wait(2000)
+                this.bot.log(this.bot.isMobile, 'LOGIN', 'Skipped 2FA')
+            } else {
+                this.bot.log(this.bot.isMobile, 'LOGIN', 'No 2FA skip button found, proceeding with password entry')
+            }
+            const viewFooter = await page.waitForSelector('#view > div > span:nth-child(6)', { timeout: 2000 }).catch(() => null)
+            const passwordField1 = await page.waitForSelector(passwordInputSelector, { timeout: 5000 }).catch(() => null)
+            if (viewFooter && !passwordField1) {
                 this.bot.log(this.bot.isMobile, 'LOGIN', 'Page "Get a code to sign in" found by "viewFooter"')
 
                 const otherWaysButton = await viewFooter.$('span[role="button"]')
@@ -142,7 +152,6 @@ export class Login {
                     if (await secondListItem.isVisible()) {
                         await secondListItem.click()
                     }
-
                 }
             }
 


### PR DESCRIPTION
I found two ways to skip 2FA.
In the first image, the code does not handle this situation: in this case, you need to click “use your password instead.”
In the second image, the code handles this situation, but it clicks “Already received a code” because it is the first element that satisfies `[data-testid=“viewFooter”]`.
I added the handling logic for the first situation and modified the handling logic for the second situation.
<img width="365" height="480" alt="image" src="https://github.com/user-attachments/assets/0866c934-0ea5-4ae2-9296-403774f1c506" />
<img width="365" height="480" alt="image" src="https://github.com/user-attachments/assets/cf04df82-3634-416c-838f-180b147677b9" />
