### PR TITLE
[DOCKER] fix overlapping script run logic

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,5 @@
 services:
-  netsky:
+  microsoft-rewards-script:
     build: .
     container_name: microsoft-rewards-script
     restart: unless-stopped
@@ -14,12 +14,15 @@ services:
       TZ: "America/Toronto" # Set your timezone for proper scheduling
       NODE_ENV: "production"
       CRON_SCHEDULE: "0 7,16,20 * * *" # Customize your schedule, use crontab.guru for formatting
-      RUN_ON_START: "true" # Runs the script on container startup
+      RUN_ON_START: "true" # Runs the script immediately on container startup
 
-      # Start-time randomization (uncomment to customize or disable)
+      # Add scheduled start-time randomization (uncomment to customize or disable, default: enabled)
       #MIN_SLEEP_MINUTES: "5"
       #MAX_SLEEP_MINUTES: "50"
       SKIP_RANDOM_SLEEP: "false"
+
+      # Optionally set how long to wait before killing a stuck script run (prevents blocking future runs, default: 8 hours)
+      #STUCK_PROCESS_TIMEOUT_HOURS: "8"
 
     # Optional resource limits for the container
     mem_limit: 4g

--- a/src/run_daily.sh
+++ b/src/run_daily.sh
@@ -10,12 +10,81 @@ export TZ="${TZ:-UTC}"
 # Change to project directory
 cd /usr/src/microsoft-rewards-script
 
-# Optional: prevent overlapping runs
+# Robust locking mechanism
 LOCKFILE=/tmp/run_daily.lock
-exec 9>"$LOCKFILE"
-if ! flock -n 9; then
-  echo "[$(date)] [run_daily.sh] Previous instance still running; exiting."
-  exit 0
+
+# Function to acquire lock with timeout and stale lock detection
+acquire_lock() {
+    local max_attempts=5
+    local attempt=0
+    
+    while [ $attempt -lt $max_attempts ]; do
+        # Try to acquire lock
+        if (set -C; echo $ > "$LOCKFILE") 2>/dev/null; then
+            echo "[$(date)] [run_daily.sh] Lock acquired successfully (PID: $)"
+            return 0
+        fi
+        
+        # Check if existing lock is stale
+        if [ -f "$LOCKFILE" ]; then
+            local existing_pid
+            existing_pid=$(cat "$LOCKFILE" 2>/dev/null || echo "")
+            
+            if [ -n "$existing_pid" ]; then
+                # Check if process is dead
+                if ! kill -0 "$existing_pid" 2>/dev/null; then
+                    echo "[$(date)] [run_daily.sh] Removing stale lock (dead PID: $existing_pid)"
+                    rm -f "$LOCKFILE"
+                    continue
+                fi
+                
+                # Check if process is older than configured timeout (default 8 hours)
+                local timeout_hours=${STUCK_PROCESS_TIMEOUT_HOURS:-8}
+                local timeout_seconds=$((timeout_hours * 3600))
+                local process_age
+                if process_age=$(ps -o etimes= -p "$existing_pid" 2>/dev/null | tr -d ' '); then
+                    if [ "$process_age" -gt "$timeout_seconds" ]; then
+                        echo "[$(date)] [run_daily.sh] Process $existing_pid has been running for ${process_age}s (>${timeout_hours}h), considering it stuck"
+                        echo "[$(date)] [run_daily.sh] Killing stuck process $existing_pid"
+                        kill -TERM "$existing_pid" 2>/dev/null || true
+                        sleep 5
+                        kill -KILL "$existing_pid" 2>/dev/null || true
+                        rm -f "$LOCKFILE"
+                        continue
+                    else
+                        echo "[$(date)] [run_daily.sh] Process $existing_pid still running (${process_age}s), but within normal range"
+                    fi
+                fi
+            fi
+        fi
+        
+        echo "[$(date)] [run_daily.sh] Lock held by PID $existing_pid, attempt $((attempt + 1))/$max_attempts"
+        sleep 2
+        ((attempt++))
+    done
+    
+    echo "[$(date)] [run_daily.sh] Could not acquire lock after $max_attempts attempts; exiting."
+    return 1
+}
+
+# Function to release lock
+release_lock() {
+    if [ -f "$LOCKFILE" ]; then
+        local lock_pid
+        lock_pid=$(cat "$LOCKFILE" 2>/dev/null || echo "")
+        if [ "$lock_pid" = "$$" ]; then
+            rm -f "$LOCKFILE"
+            echo "[$(date)] [run_daily.sh] Lock released"
+        fi
+    fi
+}
+
+# Set up cleanup trap - this runs on ANY exit (success, failure, signal)
+trap 'release_lock' EXIT INT TERM
+
+# Try to acquire the lock
+if ! acquire_lock; then
+    exit 0
 fi
 
 # Random sleep between configurable minutes (default 5-50 minutes)
@@ -40,3 +109,6 @@ if npm start; then
 else
   echo "[$(date)] [run_daily.sh] ERROR: Script failed!" >&2
 fi
+
+echo "[$(date)] [run_daily.sh] Script finished"
+# Lock will be released automatically via EXIT trap


### PR DESCRIPTION
I had previously added a lock file to prevent a scheduled run from starting up while the script was already running. 

This PR fixes a potential situation where the script is blocked from starting on schedule even though a prior run was finished, when the prior run didn't finish cleanly or exit properly. 

The default time for considering a script 'stuck' is 8 hrs, and can be optionally customized in the compose.yaml. That means if a schedule run starts and it's been >8hrs since the last, it'll kill the previous process assuming it's stuck and not actually 'running', and start a fresh run.

Non-urgent.




