### PR TITLE
Fix headless in new version of edge(139.0.3405.111)

### DIFF
--- a/src/browser/Browser.ts
+++ b/src/browser/Browser.ts
@@ -25,8 +25,10 @@ class Browser {
     }
 
     async createBrowser(proxy: AccountProxy, email: string): Promise<BrowserContext> {
+        const headless = this.bot.config.headless ? "--headless=new" : ""
+		
         const browser = await playwright.chromium.launch({
-            //channel: 'msedge', // Uses Edge instead of chrome
+            channel: 'msedge', // Uses Edge instead of chrome
             headless: this.bot.config.headless,
             ...(proxy.url && { proxy: { username: proxy.username, password: proxy.password, server: `${proxy.url}:${proxy.port}` } }),
             args: [
@@ -35,7 +37,8 @@ class Browser {
                 '--disable-setuid-sandbox',
                 '--ignore-certificate-errors',
                 '--ignore-certificate-errors-spki-list',
-                '--ignore-ssl-errors'
+                '--ignore-ssl-errors',
+				`${headless}`
             ]
         })
 


### PR DESCRIPTION
When setting `"headless" : true` in `config.json`, new version of edge(139.0.3405.111) would throw an error:

> Old Headless mode has been removed from the Microsoft Edge binary. Please use the new Headless mode (https://developer.chrome.com/docs/chromium/new-headless) or the chrome-headless-shell which is a standalone implementation of the old Headless mode (https://developer.chrome.com/blog/chrome-headless-shell).

This pull request is up to fixing this problem