### PR TITLE
Improvements to docker scheduling and lock file

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,24 +35,16 @@ Under development, however mainly for personal use!
 
 2. **Update `accounts.json`**
 
-3. **Edit `config.json`,** ensuring the following values are set (other settings are up to your preference):
-
-   ```json
-   "headless": true,
-   "clusters": 1,
-   ```
+3. **Edit `config.json`,** ensuring "headless": true, other settings are up to your preference
 
 ### **Customize the `compose.yaml` File**
 
 A basic docker `compose.yaml` is provided. Follow these steps to configure and run the container:
 
 1. **Set Your Timezone:** Adjust the `TZ` variable to ensure correct scheduling.
-2. **Configure Persistent Storage:**
-   - Map `config.json` and `accounts.json` to retain settings and accounts.
-   - (Optional) Use a persistent `sessions` folder to save login sessions.
 3. **Customize the Schedule:**
    - Modify `CRON_SCHEDULE` to set run times. Use [crontab.guru](https://crontab.guru) for help.
-   - **Note:** The container adds 5–50 minutes of random variability to each scheduled start time.
+   - **Note:** The container adds 5–50 minutes of random variability to each scheduled start time. This can be optionally disabled or customized in the compose file.
 4. **(Optional) Run on Startup:**
    - Set `RUN_ON_START=true` to execute the script immediately when the container starts.
 5. **Start the Container:** Run `docker compose up -d` to build and launch.

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,5 @@
 services:
-  netsky:
+  microsoft-rewards-script:
     build: .
     container_name: microsoft-rewards-script
     restart: unless-stopped
@@ -14,12 +14,15 @@ services:
       TZ: "America/Toronto" # Set your timezone for proper scheduling
       NODE_ENV: "production"
       CRON_SCHEDULE: "0 7,16,20 * * *" # Customize your schedule, use crontab.guru for formatting
-      RUN_ON_START: "true" # Runs the script on container startup
+      RUN_ON_START: "true" # Runs the script immediately on container startup
 
-      # Start-time randomization (uncomment to customize or disable)
+      # Add scheduled start-time randomization (uncomment to customize or disable, default: enabled)
       #MIN_SLEEP_MINUTES: "5"
       #MAX_SLEEP_MINUTES: "50"
       SKIP_RANDOM_SLEEP: "false"
+
+      # Optionally set how long to wait before killing a stuck script run (prevents blocking future runs, default: 8 hours)
+      #STUCK_PROCESS_TIMEOUT_HOURS: "8"
 
     # Optional resource limits for the container
     mem_limit: 4g

--- a/src/run_daily.sh
+++ b/src/run_daily.sh
@@ -1,114 +1,155 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Ensure Playwright uses the preinstalled browsers
 export PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
-
-# Ensure TZ is set (entrypoint sets TZ system-wide); fallback if missing
 export TZ="${TZ:-UTC}"
 
-# Change to project directory
 cd /usr/src/microsoft-rewards-script
 
-# Robust locking mechanism
 LOCKFILE=/tmp/run_daily.lock
 
-# Function to acquire lock with timeout and stale lock detection
-acquire_lock() {
-    local max_attempts=5
-    local attempt=0
-    
-    while [ $attempt -lt $max_attempts ]; do
-        # Try to acquire lock
-        if (set -C; echo $ > "$LOCKFILE") 2>/dev/null; then
-            echo "[$(date)] [run_daily.sh] Lock acquired successfully (PID: $)"
-            return 0
-        fi
-        
-        # Check if existing lock is stale
-        if [ -f "$LOCKFILE" ]; then
-            local existing_pid
-            existing_pid=$(cat "$LOCKFILE" 2>/dev/null || echo "")
-            
-            if [ -n "$existing_pid" ]; then
-                # Check if process is dead
-                if ! kill -0 "$existing_pid" 2>/dev/null; then
-                    echo "[$(date)] [run_daily.sh] Removing stale lock (dead PID: $existing_pid)"
-                    rm -f "$LOCKFILE"
-                    continue
-                fi
-                
-                # Check if process is older than configured timeout (default 8 hours)
-                local timeout_hours=${STUCK_PROCESS_TIMEOUT_HOURS:-8}
-                local timeout_seconds=$((timeout_hours * 3600))
-                local process_age
-                if process_age=$(ps -o etimes= -p "$existing_pid" 2>/dev/null | tr -d ' '); then
-                    if [ "$process_age" -gt "$timeout_seconds" ]; then
-                        echo "[$(date)] [run_daily.sh] Process $existing_pid has been running for ${process_age}s (>${timeout_hours}h), considering it stuck"
-                        echo "[$(date)] [run_daily.sh] Killing stuck process $existing_pid"
-                        kill -TERM "$existing_pid" 2>/dev/null || true
-                        sleep 5
-                        kill -KILL "$existing_pid" 2>/dev/null || true
-                        rm -f "$LOCKFILE"
-                        continue
-                    else
-                        echo "[$(date)] [run_daily.sh] Process $existing_pid still running (${process_age}s), but within normal range"
-                    fi
-                fi
-            fi
-        fi
-        
-        echo "[$(date)] [run_daily.sh] Lock held by PID $existing_pid, attempt $((attempt + 1))/$max_attempts"
-        sleep 2
-        ((attempt++))
-    done
-    
-    echo "[$(date)] [run_daily.sh] Could not acquire lock after $max_attempts attempts; exiting."
-    return 1
-}
-
-# Function to release lock
-release_lock() {
+# -------------------------------
+#  Function: Check and fix lockfile integrity
+# -------------------------------
+self_heal_lockfile() {
+    # If lockfile exists but is empty → remove it
     if [ -f "$LOCKFILE" ]; then
-        local lock_pid
-        lock_pid=$(cat "$LOCKFILE" 2>/dev/null || echo "")
-        if [ "$lock_pid" = "$$" ]; then
+        local lock_content
+        lock_content=$(<"$LOCKFILE" || echo "")
+
+        if [[ -z "$lock_content" ]]; then
+            echo "[$(date)] [run_daily.sh] Found empty lockfile → removing."
             rm -f "$LOCKFILE"
-            echo "[$(date)] [run_daily.sh] Lock released"
+            return
+        fi
+
+        # If lockfile contains non-numeric PID → remove it
+        if ! [[ "$lock_content" =~ ^[0-9]+$ ]]; then
+            echo "[$(date)] [run_daily.sh] Found corrupted lockfile content ('$lock_content') → removing."
+            rm -f "$LOCKFILE"
+            return
+        fi
+
+        # If lockfile contains PID but process is dead → remove it
+        if ! kill -0 "$lock_content" 2>/dev/null; then
+            echo "[$(date)] [run_daily.sh] Lockfile PID $lock_content is dead → removing stale lock."
+            rm -f "$LOCKFILE"
+            return
         fi
     fi
 }
 
-# Set up cleanup trap - this runs on ANY exit (success, failure, signal)
+# -------------------------------
+#  Function: Acquire lock
+# -------------------------------
+acquire_lock() {
+    local max_attempts=5
+    local attempt=0
+    local timeout_hours=${STUCK_PROCESS_TIMEOUT_HOURS:-8}
+    local timeout_seconds=$((timeout_hours * 3600))
+
+    while [ $attempt -lt $max_attempts ]; do
+        # Try to create lock with current PID
+        if (set -C; echo "$$" > "$LOCKFILE") 2>/dev/null; then
+            echo "[$(date)] [run_daily.sh] Lock acquired successfully (PID: $$)"
+            return 0
+        fi
+
+        # Lock exists, validate it
+        if [ -f "$LOCKFILE" ]; then
+            local existing_pid
+            existing_pid=$(<"$LOCKFILE" || echo "")
+
+            echo "[$(date)] [run_daily.sh] Lock file exists with PID: '$existing_pid'"
+
+            # If lockfile content is invalid → delete and retry
+            if [[ -z "$existing_pid" || ! "$existing_pid" =~ ^[0-9]+$ ]]; then
+                echo "[$(date)] [run_daily.sh] Removing invalid lockfile → retrying..."
+                rm -f "$LOCKFILE"
+                continue
+            fi
+
+            # If process is dead → delete and retry
+            if ! kill -0 "$existing_pid" 2>/dev/null; then
+                echo "[$(date)] [run_daily.sh] Removing stale lock (dead PID: $existing_pid)"
+                rm -f "$LOCKFILE"
+                continue
+            fi
+
+            # Check process runtime → kill if exceeded timeout
+            local process_age
+            if process_age=$(ps -o etimes= -p "$existing_pid" 2>/dev/null | tr -d ' '); then
+                if [ "$process_age" -gt "$timeout_seconds" ]; then
+                    echo "[$(date)] [run_daily.sh] Killing stuck process $existing_pid (${process_age}s > ${timeout_hours}h)"
+                    kill -TERM "$existing_pid" 2>/dev/null || true
+                    sleep 5
+                    kill -KILL "$existing_pid" 2>/dev/null || true
+                    rm -f "$LOCKFILE"
+                    continue
+                fi
+            fi
+        fi
+
+        echo "[$(date)] [run_daily.sh] Lock held by PID $existing_pid, attempt $((attempt + 1))/$max_attempts"
+        sleep 2
+        ((attempt++))
+    done
+
+    echo "[$(date)] [run_daily.sh] Could not acquire lock after $max_attempts attempts; exiting."
+    return 1
+}
+
+# -------------------------------
+#  Function: Release lock
+# -------------------------------
+release_lock() {
+    if [ -f "$LOCKFILE" ]; then
+        local lock_pid
+        lock_pid=$(<"$LOCKFILE")
+        if [ "$lock_pid" = "$$" ]; then
+            rm -f "$LOCKFILE"
+            echo "[$(date)] [run_daily.sh] Lock released (PID: $$)"
+        fi
+    fi
+}
+
+# Always release lock on exit — but only if we acquired it
 trap 'release_lock' EXIT INT TERM
 
-# Try to acquire the lock
+# -------------------------------
+#  MAIN EXECUTION FLOW
+# -------------------------------
+echo "[$(date)] [run_daily.sh] Current process PID: $$"
+
+# Self-heal any broken or empty locks before proceeding
+self_heal_lockfile
+
+# Attempt to acquire the lock safely
 if ! acquire_lock; then
     exit 0
 fi
 
-# Random sleep between configurable minutes (default 5-50 minutes)
+# Random sleep between MIN and MAX to spread execution
 MINWAIT=${MIN_SLEEP_MINUTES:-5}
 MAXWAIT=${MAX_SLEEP_MINUTES:-50}
 MINWAIT_SEC=$((MINWAIT*60))
 MAXWAIT_SEC=$((MAXWAIT*60))
 
-# Skip sleep if SKIP_RANDOM_SLEEP is set to true
 if [ "${SKIP_RANDOM_SLEEP:-false}" != "true" ]; then
     SLEEPTIME=$(( MINWAIT_SEC + RANDOM % (MAXWAIT_SEC - MINWAIT_SEC) ))
-    SLEEP_MINUTES=$(( SLEEPTIME / 60 ))
-    echo "[$(date)] [run_daily.sh] Sleeping for $SLEEP_MINUTES minutes ($SLEEPTIME seconds) to randomize execution..."
+    echo "[$(date)] [run_daily.sh] Sleeping for $((SLEEPTIME/60)) minutes ($SLEEPTIME seconds)"
     sleep "$SLEEPTIME"
 else
-    echo "[$(date)] [run_daily.sh] Skipping random sleep (SKIP_RANDOM_SLEEP=true)"
+    echo "[$(date)] [run_daily.sh] Skipping random sleep"
 fi
 
+# Start the actual script
 echo "[$(date)] [run_daily.sh] Starting script..."
 if npm start; then
-  echo "[$(date)] [run_daily.sh] Script completed successfully."
+    echo "[$(date)] [run_daily.sh] Script completed successfully."
 else
-  echo "[$(date)] [run_daily.sh] ERROR: Script failed!" >&2
+    echo "[$(date)] [run_daily.sh] ERROR: Script failed!" >&2
 fi
 
 echo "[$(date)] [run_daily.sh] Script finished"
-# Lock will be released automatically via EXIT trap
+# Lock is released automatically via trap

--- a/src/run_daily.sh
+++ b/src/run_daily.sh
@@ -10,12 +10,81 @@ export TZ="${TZ:-UTC}"
 # Change to project directory
 cd /usr/src/microsoft-rewards-script
 
-# Optional: prevent overlapping runs
+# Robust locking mechanism
 LOCKFILE=/tmp/run_daily.lock
-exec 9>"$LOCKFILE"
-if ! flock -n 9; then
-  echo "[$(date)] [run_daily.sh] Previous instance still running; exiting."
-  exit 0
+
+# Function to acquire lock with timeout and stale lock detection
+acquire_lock() {
+    local max_attempts=5
+    local attempt=0
+    
+    while [ $attempt -lt $max_attempts ]; do
+        # Try to acquire lock
+        if (set -C; echo $ > "$LOCKFILE") 2>/dev/null; then
+            echo "[$(date)] [run_daily.sh] Lock acquired successfully (PID: $)"
+            return 0
+        fi
+        
+        # Check if existing lock is stale
+        if [ -f "$LOCKFILE" ]; then
+            local existing_pid
+            existing_pid=$(cat "$LOCKFILE" 2>/dev/null || echo "")
+            
+            if [ -n "$existing_pid" ]; then
+                # Check if process is dead
+                if ! kill -0 "$existing_pid" 2>/dev/null; then
+                    echo "[$(date)] [run_daily.sh] Removing stale lock (dead PID: $existing_pid)"
+                    rm -f "$LOCKFILE"
+                    continue
+                fi
+                
+                # Check if process is older than configured timeout (default 8 hours)
+                local timeout_hours=${STUCK_PROCESS_TIMEOUT_HOURS:-8}
+                local timeout_seconds=$((timeout_hours * 3600))
+                local process_age
+                if process_age=$(ps -o etimes= -p "$existing_pid" 2>/dev/null | tr -d ' '); then
+                    if [ "$process_age" -gt "$timeout_seconds" ]; then
+                        echo "[$(date)] [run_daily.sh] Process $existing_pid has been running for ${process_age}s (>${timeout_hours}h), considering it stuck"
+                        echo "[$(date)] [run_daily.sh] Killing stuck process $existing_pid"
+                        kill -TERM "$existing_pid" 2>/dev/null || true
+                        sleep 5
+                        kill -KILL "$existing_pid" 2>/dev/null || true
+                        rm -f "$LOCKFILE"
+                        continue
+                    else
+                        echo "[$(date)] [run_daily.sh] Process $existing_pid still running (${process_age}s), but within normal range"
+                    fi
+                fi
+            fi
+        fi
+        
+        echo "[$(date)] [run_daily.sh] Lock held by PID $existing_pid, attempt $((attempt + 1))/$max_attempts"
+        sleep 2
+        ((attempt++))
+    done
+    
+    echo "[$(date)] [run_daily.sh] Could not acquire lock after $max_attempts attempts; exiting."
+    return 1
+}
+
+# Function to release lock
+release_lock() {
+    if [ -f "$LOCKFILE" ]; then
+        local lock_pid
+        lock_pid=$(cat "$LOCKFILE" 2>/dev/null || echo "")
+        if [ "$lock_pid" = "$$" ]; then
+            rm -f "$LOCKFILE"
+            echo "[$(date)] [run_daily.sh] Lock released"
+        fi
+    fi
+}
+
+# Set up cleanup trap - this runs on ANY exit (success, failure, signal)
+trap 'release_lock' EXIT INT TERM
+
+# Try to acquire the lock
+if ! acquire_lock; then
+    exit 0
 fi
 
 # Random sleep between configurable minutes (default 5-50 minutes)
@@ -40,3 +109,6 @@ if npm start; then
 else
   echo "[$(date)] [run_daily.sh] ERROR: Script failed!" >&2
 fi
+
+echo "[$(date)] [run_daily.sh] Script finished"
+# Lock will be released automatically via EXIT trap


### PR DESCRIPTION
I had previously introduced some basic logic for docker to prevent a cron-scheduled run from starting if there was already an active run in progress. This was done via a lock file. 

This PR improves this logic to handle situations where the lockfile might become stuck because when a previous run didn't exit or finish cleanly (e.g, #337), which would block new runs from starting. This is particularly useful if a user has desktop searches working and mobile searches broken, but still wants scheduling to run properly. I've been testing for about a week now on my end with a few tweaks and tidy-ups along the way.

> Note: I added an option to customize the time before docker assumes the script is stuck. The default is 8 hours, which should handle #331, but if a user needs longer they can customize this in the compose.yaml.

PR includes fixes for run_daily.sh (which handles the scheduling and lock), and some minor tidying up of the docker instructions in the README, and the sample compose.yaml


