### PR TITLE
fix scheduler exit suddenly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1291,8 +1291,10 @@ async function main() {
 }
 
 // Start the bots
-main().catch(error => {
-    log('main', 'MAIN-ERROR', `Error running bots: ${error}`, 'error')
-    // CommunityReporter disabled
-    process.exit(1)
-})
+if (require.main === module) {
+    main().catch(error => {
+        log('main', 'MAIN-ERROR', `Error running bots: ${error}`, 'error')
+        // CommunityReporter disabled
+        process.exit(1)
+    })
+}


### PR DESCRIPTION
Import index.ts without checking main function could make the scheduler being exited with process.exit() after executing function runTasks(). I made a small change to handle it.