### PR TITLE
Update run_daily.sh

### DIFF
--- a/src/run_daily.sh
+++ b/src/run_daily.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+export PATH="/usr/local/bin:/usr/bin:/bin"
 export PLAYWRIGHT_BROWSERS_PATH=0
 export TZ="${TZ:-UTC}"
 


### PR DESCRIPTION
This is a quick fix for a bug I introduced in the 1.53 scheduler when updating the dockerfile.
Fixes `starting script... /usr/src/microsoft-rewards-script/src/run_daily.sh: line 148: npm: command not found`