### PR TITLE
Dockerfile, handle non-unix docker users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,6 +82,7 @@ COPY --from=builder /usr/src/microsoft-rewards-script/node_modules ./node_module
 # Copy runtime scripts with proper permissions from the start
 COPY --chmod=755 src/run_daily.sh ./src/run_daily.sh
 COPY --chmod=644 src/crontab.template /etc/cron.d/microsoft-rewards-cron.template
+COPY --chmod=755 entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod 755 /usr/local/bin/entrypoint.sh \
     && sed -i 's/\r$//' /usr/local/bin/entrypoint.sh
 


### PR DESCRIPTION
Added a small adjustment in the Dockerfile to ensure entrypoint.sh has correct Unix-style line endings (LF). This prevents `permission denied` errors for users building the image on Windows or other non-Unix environments. Should close #407 