### PR TITLE
fix: fallback to 'us' when userProfile.country is undefined

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -374,7 +374,9 @@ export class MicrosoftRewardsBot {
 
                 // Set geo
                 this.userData.geoLocale =
-                    account.geoLocale === 'auto' ? data.userProfile.attributes.country : account.geoLocale.toLowerCase()
+                    account.geoLocale === 'auto'
+                        ? (data.userProfile?.attributes?.country ?? 'us')
+                        : (account.geoLocale?.toLowerCase() ?? 'us')
                 if (this.userData.geoLocale.length > 2) {
                     this.logger.warn(
                         'main',


### PR DESCRIPTION
Fixes an issue I was getting:
```
[INFO] MOBILE [LOGIN] Login completed! Session saved!
[INFO] MOBILE [LOGIN-APP] Waiting for mobile OAuth code...
[INFO] MOBILE [LOGIN-APP] Mobile access token received
[INFO] MOBILE [CLOSE-BROWSER] Browser closed cleanly!
[ERROR] MOBILE [FLOW] Mobile flow failed for [REDACTED]: Cannot read properties of undefined (reading 'toLowerCase')
```

Seems that this `country` value may not be populated in some cases.