### PR TITLE
Add .dockerignore to exclude dist and node_modules

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+dist
+node_modules


### PR DESCRIPTION
no need to delete dist and node_modules folder when running docker compose up