### PR TITLE
Add new state for bot to detect "use your password" prompt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
     "name": "microsoft-rewards-script",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "microsoft-rewards-script",
-            "version": "3.0.0",
-            "license": "ISC",
+            "version": "3.0.1",
+            "license": "GPL-3.0-or-later",
             "dependencies": {
                 "axios": "^1.13.2",
                 "axios-retry": "^4.5.0",
@@ -25,6 +25,7 @@
                 "ts-node": "^10.9.2"
             },
             "devDependencies": {
+                "@types/cheerio": "^0.22.35",
                 "@types/ms": "^2.1.0",
                 "@types/node": "^24.10.1",
                 "@typescript-eslint/eslint-plugin": "^8.48.0",
@@ -417,6 +418,16 @@
             "resolved": "https://registry.npmjs.org/@types/bezier-js/-/bezier-js-4.1.3.tgz",
             "integrity": "sha512-FNVVCu5mx/rJCWBxLTcL7oOajmGtWtBTDjq6DSUWUI12GeePivrZZXz+UgE0D6VYsLEjvExRO03z4hVtu3pTEQ==",
             "license": "MIT"
+        },
+        "node_modules/@types/cheerio": {
+            "version": "0.22.35",
+            "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.35.tgz",
+            "integrity": "sha512-yD57BchKRvTV+JD53UZ6PD8KWY5g5rvvMLRnZR3EQBCZXiDT/HR+pKpMzFGlWNhFrXlo7VPZXtKvIEwZkAWOIA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/@types/estree": {
             "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "Cheerio"
     ],
     "devDependencies": {
+        "@types/cheerio": "^0.22.35",
         "@types/ms": "^2.1.0",
         "@types/node": "^24.10.1",
         "@typescript-eslint/eslint-plugin": "^8.48.0",

--- a/src/browser/Browser.ts
+++ b/src/browser/Browser.ts
@@ -35,7 +35,7 @@ class Browser {
         try {
             browser = await rebrowser.chromium.launch({
                 headless: this.bot.config.headless,
-                ...(proxy.url && {
+                ...(proxy?.url && {
                     proxy: { username: proxy.username, password: proxy.password, server: `${proxy.url}:${proxy.port}` }
                 }),
                 args: [

--- a/src/browser/BrowserUtils.ts
+++ b/src/browser/BrowserUtils.ts
@@ -1,5 +1,5 @@
 import { type Page, type BrowserContext } from 'patchright'
-import { CheerioAPI, load } from 'cheerio'
+import {load} from 'cheerio'
 import { ClickOptions, createCursor } from 'ghost-cursor-playwright-port'
 
 import type { MicrosoftRewardsBot } from '../index'
@@ -205,7 +205,7 @@ export default class BrowserUtils {
         }
     }
 
-    async loadInCheerio(data: Page | string): Promise<CheerioAPI> {
+	async loadInCheerio(data: Page | string): Promise<cheerio.Root> {
         const html: string = typeof data === 'string' ? data : await data.content()
         const $ = load(html)
         return $

--- a/src/browser/auth/Login.ts
+++ b/src/browser/auth/Login.ts
@@ -11,6 +11,7 @@ import { TotpLogin } from './methods/Totp2FALogin'
 type LoginState =
     | 'EMAIL_INPUT'
     | 'PASSWORD_INPUT'
+	| 'USE_YOUR_PASSWORD'
     | 'SIGN_IN_ANOTHER_WAY'
     | 'PASSKEY_ERROR'
     | 'PASSKEY_VIDEO'
@@ -155,6 +156,7 @@ export class Login {
         const results = await Promise.all([
             check('div[role="alert"]', 'ERROR_ALERT'),
             check('[data-testid="passwordEntry"]', 'PASSWORD_INPUT'),
+			check('text="Use your password"', 'USE_YOUR_PASSWORD'),
             check('input#usernameEntry', 'EMAIL_INPUT'),
             check('[data-testid="kmsiVideo"]', 'KMSI_PROMPT'),
             check('[data-testid="biometricVideo"]', 'PASSKEY_VIDEO'),
@@ -257,6 +259,13 @@ export class Login {
                 await page.waitForLoadState('networkidle', { timeout: 5000 }).catch(() => {})
                 return true
             }
+
+			case 'USE_YOUR_PASSWORD': {
+				this.bot.logger.info(this.bot.isMobile, 'LOGIN', 'Switching to using a password')
+				await this.bot.browser.utils.ghostClick(page, 'text="Use your password"')
+				await page.waitForLoadState('networkidle', { timeout: 5000 }).catch(() => {})
+				return true
+			}
 
             case 'GET_A_CODE': {
                 this.bot.logger.info(this.bot.isMobile, 'LOGIN', 'Attempting to bypass "Get code"')

--- a/src/util/Axios.ts
+++ b/src/util/Axios.ts
@@ -16,7 +16,7 @@ class AxiosClient {
             timeout: 20000
         })
 
-        if (this.account.url && this.account.proxyAxios) {
+        if (this.account?.url && this.account?.proxyAxios) {
             const agent = this.getAgentForProxy(this.account)
             this.instance.defaults.httpAgent = agent
             this.instance.defaults.httpsAgent = agent


### PR DESCRIPTION
This adds a new state for the login flow to be used.

It also optionally chains the `proxy` properties so that can be omitted from the accounts json, and also fixes the cheerio typings.

This should fix #429 