### PR TITLE
fix: select wrong button when Attempting to bypass "Get code"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ accounts.dev.json
 accounts.main.json
 .DS_Store
 .playwright-chromium-installed
+bun.lock

--- a/src/browser/auth/Login.ts
+++ b/src/browser/auth/Login.ts
@@ -55,7 +55,7 @@ export class Login {
         totpInput: 'input[name="otc"]',
         totpInputOld: 'form[name="OneTimeCodeViewForm"]',
         identityBanner: '[data-testid="identityBanner"]',
-        viewFooter: '[data-testid="viewFooter"] span[role="button"]',
+        viewFooter: '[data-testid="viewFooter"] span[role="button"] >> nth=-1',
         bingProfile: '#id_n',
         requestToken: 'input[name="__RequestVerificationToken"]',
         requestTokenMeta: 'meta[name="__RequestVerificationToken"]'


### PR DESCRIPTION
When bot state is "GET_A_CODE", it tries to press "Use your password" button. Actually, like this picture, there is two buttons matched `[data-testid="viewFooter"] span[role="button"]`("Already received a code" and "Use your password"), the bot need to press the last(second) one.
<img width="508" height="921" alt="pic1" src="https://github.com/user-attachments/assets/99d81543-661b-41ec-9608-2d8244c63c1b" />

