### PR TITLE
fix: try fixing error fetching dashboard data on mobile func

### DIFF
--- a/src/browser/BrowserFunc.ts
+++ b/src/browser/BrowserFunc.ts
@@ -23,9 +23,24 @@ export default class BrowserFunc {
      */
     async getDashboardData(): Promise<DashboardData> {
         try {
-            const cookieHeader = this.bot.cookies.mobile
-                .map((c: { name: string; value: string }) => `${c.name}=${c.value}`)
-                .join('; ')
+            const allowedDomains = ['bing.com', 'live.com', 'microsoftonline.com'];
+
+            const cookieHeader = [
+            ...new Map(
+                this.bot.cookies.mobile
+                .filter(
+                    (c: { name: string; value: string; domain?: string }) =>
+                    typeof c.domain === 'string' &&
+                    allowedDomains.some(d =>
+                        c.domain && c.domain.toLowerCase().endsWith(d)
+                    )
+                )
+                .map(c => [c.name, c]) // dedupe by name, keep last
+            ).values()
+            ]
+            .map(c => `${c.name}=${c.value}`)
+            .join('; ');
+
 
             const request: AxiosRequestConfig = {
                 url: 'https://rewards.bing.com/api/getuserinfo?type=1',


### PR DESCRIPTION
because cookieHeader param has too much cookies from other sites, the server could return 400 that said too much header context, so I try to fix it by adding allowed domains to use these cookies only.