### PR TITLE
Fix OTP/passkey login flow handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ accounts.main.json
 .DS_Store
 .playwright-chromium-installed
 bun.lock
+logs/
+.stfolder/

--- a/src/logging/Logger.ts
+++ b/src/logging/Logger.ts
@@ -45,7 +45,7 @@ function formatMessage(message: string | Error): string {
 }
 
 export class Logger {
-    constructor(private bot: MicrosoftRewardsBot) {}
+    constructor(private bot: MicrosoftRewardsBot) { }
 
     info(isMobile: Platform, title: string, message: string, color?: ColorKey) {
         return this.baseLog('info', isMobile, title, message, color)
@@ -180,7 +180,7 @@ export class Logger {
                         isMatch = true
                         break
                     }
-                } catch {}
+                } catch { }
             }
         }
 


### PR DESCRIPTION
Some issues cropped up with the login flow resulting from [3.1.0](https://github.com/TheNetsky/Microsoft-Rewards-Script/commit/576899f39d662a8501a0c751310a0fdee49fc316).

Specifically I was hitting failures with the passkey creation, which fails. I don't know why this stuff was being activated in the first place, but I added code that will just skip it.

I also was hitting issues with the bot getting lost on the login flow and ending up on the OTP page. I am not 100% about this code though.


Closes: #449 & #429