### PR TITLE
fix: reduced cookie header length when calling with bing rewards api

### DIFF
--- a/src/functions/activities/api/DoubleSearchPoints.ts
+++ b/src/functions/activities/api/DoubleSearchPoints.ts
@@ -22,7 +22,11 @@ export class DoubleSearchPoints extends Workers {
             }
 
             this.cookieHeader = this.bot.browser.func.buildCookieHeader(
-                this.bot.isMobile ? this.bot.cookies.mobile : this.bot.cookies.desktop
+                this.bot.isMobile ? this.bot.cookies.mobile : this.bot.cookies.desktop, [
+                    'bing.com',
+                    'live.com',
+                    'microsoftonline.com'
+                ]
             )
 
             const fingerprintHeaders = { ...this.bot.fingerprint.headers }

--- a/src/functions/activities/api/FindClippy.ts
+++ b/src/functions/activities/api/FindClippy.ts
@@ -26,7 +26,11 @@ export class FindClippy extends Workers {
             }
 
             this.cookieHeader = this.bot.browser.func.buildCookieHeader(
-                this.bot.isMobile ? this.bot.cookies.mobile : this.bot.cookies.desktop
+                this.bot.isMobile ? this.bot.cookies.mobile : this.bot.cookies.desktop, [
+                    'bing.com',
+                    'live.com',
+                    'microsoftonline.com'
+                ]
             )
 
             const fingerprintHeaders = { ...this.bot.fingerprint.headers }

--- a/src/functions/activities/api/Quiz.ts
+++ b/src/functions/activities/api/Quiz.ts
@@ -24,7 +24,11 @@ export class Quiz extends Workers {
 
         try {
             this.cookieHeader = this.bot.browser.func.buildCookieHeader(
-                this.bot.isMobile ? this.bot.cookies.mobile : this.bot.cookies.desktop
+                this.bot.isMobile ? this.bot.cookies.mobile : this.bot.cookies.desktop, [
+                    'bing.com',
+                    'live.com',
+                    'microsoftonline.com'
+                ]
             )
 
             const fingerprintHeaders = { ...this.bot.fingerprint.headers }

--- a/src/functions/activities/api/UrlReward.ts
+++ b/src/functions/activities/api/UrlReward.ts
@@ -31,7 +31,11 @@ export class UrlReward extends Workers {
 
         try {
             this.cookieHeader = this.bot.browser.func.buildCookieHeader(
-                this.bot.isMobile ? this.bot.cookies.mobile : this.bot.cookies.desktop
+                this.bot.isMobile ? this.bot.cookies.mobile : this.bot.cookies.desktop, [
+                    'bing.com',
+                    'live.com',
+                    'microsoftonline.com'
+                ]
             )
 
             const fingerprintHeaders = { ...this.bot.fingerprint.headers }

--- a/src/functions/activities/browser/SearchOnBing.ts
+++ b/src/functions/activities/browser/SearchOnBing.ts
@@ -33,7 +33,11 @@ export class SearchOnBing extends Workers {
 
         try {
             this.cookieHeader = this.bot.browser.func.buildCookieHeader(
-                this.bot.isMobile ? this.bot.cookies.mobile : this.bot.cookies.desktop
+                this.bot.isMobile ? this.bot.cookies.mobile : this.bot.cookies.desktop, [
+                    'bing.com',
+                    'live.com',
+                    'microsoftonline.com'
+                ]
             )
 
             const fingerprintHeaders = { ...this.bot.fingerprint.headers }


### PR DESCRIPTION
After investigating this issue for several days, I realized that the UrlReward activity also returns a 400 Bad Request error due to excessive header context. Therefore, I made this PR to reduce the header size in all requests calling the Bing Rewards API.

Need more days to analyze the result. If anyone had this problem when doing UrlReward activity, you can try this PR to see the result and leave a message to me.