### PR TITLE
Update docker compose for prebuilt image

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@
 Works on Windows, Linux, macOS, and WSL.
 
 ### Get the script
-
 ```bash
 git clone https://github.com/TheNetsky/Microsoft-Rewards-Script.git
 cd Microsoft-Rewards-Script
@@ -35,40 +34,42 @@ cd Microsoft-Rewards-Script
 
 Or, download the latest release ZIP and extract it.
 
-### Create an account.json and config.json
+> [!TIP]
+> **Docker users:** optionally skip the clone step when using the prebuilt image. You only need a valid `accounts.json` and `config.json` locally. They can be placed anywhere. 
+> Update the `volumes` section in [`compose.yaml`](./compose.yaml) to point to your files (e.g., `/your/path/to/accounts.json:/usr/src/microsoft-rewards-script/dist/accounts.json:ro`).
+
+### Create accounts.json and config.json
 
 Copy, rename, and edit your account and configuration files before deploying the script.
 
 - Copy or rename `src/accounts.example.json` to `src/accounts.json` and add your credentials
-- Copy or rename `src/config.example.json` to `src/config.json` and customize your preferences.
+- Copy or rename `src/config.example.json` to `src/config.json` and customize your preferences
 
 > [!CAUTION]
 > Do not skip this step.
-> Prior versions of accounts.json and config.json are not compatible with current release.
+> Prior versions of accounts.json and config.json are not compatible with the current release.
 
 > [!WARNING]
 > You must rebuild your script after making any changes to accounts.json and config.json.
 
-### Build and run the script (bare metal version)
-
+### Build and run the script (bare metal)
 ```bash
 npm run pre-build
 npm run build
 npm run start
 ```
 
-### Build and run the script (docker version)
-
+### Build and run the script (Docker)
 ```bash
 docker compose up -d
 ```
 
 > [!CAUTION]
-> Set `headless` to `true` in the `src/config.json` when using Docker.
-> Additional docker-specific scheduling options are in the `compose.yaml`
+> Set `headless` to `true` in `src/config.json` when using Docker.
+> Additional Docker-specific scheduling options are in `compose.yaml`.
 
 > [!TIP]
-> When headeless, monitor logs with `docker logs microsoft-rewards-script` (for example, to view passwordless codes), or enable a webhook service in the `src/config.json`.
+> When headless, monitor logs with `docker logs microsoft-rewards-script` (for example, to view passwordless codes), or enable a webhook service in `src/config.json`.
 
 ---
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,29 +1,25 @@
 services:
     microsoft-rewards-script:
-        build: .
+        image: ghcr.io/thenetsky/microsoft-rewards-script:latest
         container_name: microsoft-rewards-script
         restart: unless-stopped
-
         # Create and customize your accounts.json and config.json prior to deploying the container (default location: /src/)
+        # Default paths assume you've cloned the repo. Advanced users can point to files anywhere on their system.
         volumes:
             - ./src/accounts.json:/usr/src/microsoft-rewards-script/dist/accounts.json:ro
             - ./src/config.json:/usr/src/microsoft-rewards-script/dist/config.json:ro
             - ./sessions:/usr/src/microsoft-rewards-script/dist/browser/sessions
-
         environment:
             TZ: 'America/Toronto' # Set your timezone for proper scheduling
             NODE_ENV: 'production'
             CRON_SCHEDULE: '0 7 * * *' # Customize your schedule, use crontab.guru for formatting
             RUN_ON_START: 'true' # Runs the script immediately on container startup
-
             # Add a small random delay to the scheduled start time (uncomment to customize delay, or disable)
             #MIN_SLEEP_MINUTES: "5"
             #MAX_SLEEP_MINUTES: "50"
             SKIP_RANDOM_SLEEP: 'false'
-
             # Set a timeout for stuck script runs (default: 8h, uncomment to customize)
             #STUCK_PROCESS_TIMEOUT_HOURS: "8"
-
         # Health check: ensures cron is running, container marked unhealthy if cron stops
         healthcheck:
             test: ['CMD', 'sh', '-c', 'pgrep cron > /dev/null || exit 1']
@@ -31,7 +27,6 @@ services:
             timeout: 10s
             retries: 3
             start_period: 30s
-
         # Security hardening
         security_opt:
             - no-new-privileges:true


### PR DESCRIPTION
Updated the default `compose.yaml` from building locally to pulling the prebuilt docker image. 

When using the prebuilt image, docker users no longer need to clone the full source repo either. They do however still need a valid config and account file. I added this as a TIP to the `README.md` rather than fully changing the instructions, as cloning the repo is still an easy way to get the example config and accounts files. 

The sample compose assumes users cloned the repo with the default local locations still set as ./src/accounts.json and ./src/config.json. Advanced users can change this, likely to ./accounts.json and ./config.json or wherever they want. I added a brief comment to the compose.yaml as well to make this clear.
