### PR TITLE
Update auto-release.yml

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -104,6 +104,10 @@ jobs:
               run: |
                   echo "LOG: Docker image already exists for version ${{ steps.version.outputs.current }}. Nothing to do."
 
+            - name: Set up QEMU
+              if: steps.imgcheck.outputs.exists != 'true'
+              uses: docker/setup-qemu-action@v3
+
             - name: Set up Docker Buildx
               if: steps.imgcheck.outputs.exists != 'true'
               uses: docker/setup-buildx-action@v3
@@ -114,6 +118,7 @@ jobs:
               with:
                   context: .
                   push: true
+                  platforms: linux/amd64,linux/arm64
                   tags: |
                       ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}:${{ steps.version.outputs.current }}
                       ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}:latest


### PR DESCRIPTION
Add linux/arm64 support to prebuilt docker images. Docker images now support linux/arm64 in addition to amd64 (e.g., Arch Linux, Raspberry Pi). ARM users no longer need to manually rebuild the image using `docker buildx build --platform linux/arm64`