### PR TITLE
[FEATURE] Docker: support for setting accounts and config option directly in compose.yaml, auto creation of files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ accounts.main.json
 bun.lock
 logs/
 .stfolder/
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,10 +39,12 @@ ENV NODE_ENV=production \
     PLAYWRIGHT_BROWSERS_PATH=0 \
     FORCE_HEADLESS=1
 
-# Install minimal system libraries required for Chromium headless to run
+# Install minimal system libraries required for Chromium headless to run,
+# plus jq (for config generation/patching) and gettext-base (for envsubst)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     cron \
     gettext-base \
+    jq \
     tzdata \
     ca-certificates \
     libglib2.0-0 \
@@ -79,11 +81,23 @@ COPY --from=builder /usr/src/microsoft-rewards-script/dist ./dist
 COPY --from=builder /usr/src/microsoft-rewards-script/package*.json ./
 COPY --from=builder /usr/src/microsoft-rewards-script/node_modules ./node_modules
 
+# Copy config example into the image so entrypoint can use it as a fallback
+# when the user hasn't mounted their own config.json
+COPY src/config.example.json ./src/config.example.json
+
+# Create the config directory and symlink config.json and accounts.json into
+# dist/ so the app finds them at its expected paths, while the entrypoint
+# writes to dist/config/ which maps to the user-facing ./config/ volume mount
+RUN mkdir -p ./dist/config \
+    && ln -s /usr/src/microsoft-rewards-script/dist/config/config.json ./dist/config.json \
+    && ln -s /usr/src/microsoft-rewards-script/dist/config/accounts.json ./dist/accounts.json
+
 # Copy runtime scripts with proper permissions from the start
 COPY --chmod=755 scripts/docker/run_daily.sh ./scripts/docker/run_daily.sh
 COPY --chmod=644 src/crontab.template /etc/cron.d/microsoft-rewards-cron.template
 COPY --chmod=755 scripts/docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 
-# Entrypoint handles TZ, initial run toggle, cron templating & launch
+# Entrypoint handles TZ, accounts/config generation, initial run toggle,
+# cron templating & launch
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["sh", "-c", "echo 'Container started; cron is running.'"]

--- a/README.md
+++ b/README.md
@@ -88,93 +88,101 @@ If using Nix: `bash scripts/nix/run.sh`
 
 ## Configuration Options
 
-Edit `src/config.json` to customize behavior. Below are all currently available options.
+Edit `config.json` to customize behavior, or set `CONFIG_*` environment variables in `compose.yaml` (Docker). Below are all currently available options.
 
 > [!WARNING]
-> Rebuild the script after all changes.
+> Rebuild the script (bare metal), or recreate the container (Docker) after all config changes.
+
+> [!NOTE]
+> Docker: `CONFIG_*` variables are applied on every startup and always take precedence over `./config/config.json`. See `compose.yaml` for common options, and all available keys are listed below.
 
 ### Core
 
-| Setting                    | Type    | Default                      | Description                           |
-| -------------------------- | ------- | ---------------------------- | ------------------------------------- |
-| `baseURL`                  | string  | `"https://rewards.bing.com"` | Microsoft Rewards base URL            |
-| `sessionPath`              | string  | `"sessions"`                 | Directory to store browser sessions   |
-| `headless`                 | boolean | `false`                      | Run browser invisibly                 |
-| `clusters`                 | number  | `1`                          | Number of concurrent account clusters |
-| `errorDiagnostics`         | boolean | `false`                      | Enable error diagnostics              |
-| `searchOnBingLocalQueries` | boolean | `false`                      | Use local query list                  |
-| `globalTimeout`            | string  | `"30sec"`                    | Timeout for all actions               |
-
-> [!CAUTION]
-> Set `headless` to `true` when using docker
+| Setting                    | Type    | Default                      | Description                           | Docker environment variable   |
+| -------------------------- | ------- | ---------------------------- | ------------------------------------- | ----------------------------- |
+| `baseURL`                  | string  | `"https://rewards.bing.com"` | Microsoft Rewards base URL            |                               |
+| `sessionPath`              | string  | `"sessions"`                 | Directory to store browser sessions   |                               |
+| `headless`                 | boolean | `false`                      | Run browser invisibly                 | Always `true` in Docker       |
+| `clusters`                 | number  | `1`                          | Number of concurrent account clusters | `CONFIG_CLUSTERS`             |
+| `errorDiagnostics`         | boolean | `false`                      | Enable error diagnostics              | `CONFIG_ERROR_DIAGNOSTICS`    |
+| `searchOnBingLocalQueries` | boolean | `false`                      | Use local query list                  | `CONFIG_SEARCH_ON_BING_LOCAL` |
+| `globalTimeout`            | string  | `"30sec"`                    | Timeout for all actions               | `CONFIG_GLOBAL_TIMEOUT`       |
 
 ### Workers
 
-| Setting                       | Type    | Default | Description                 |
-| ----------------------------- | ------- | ------- | --------------------------- |
-| `workers.doDailySet`          | boolean | `true`  | Complete daily set          |
-| `workers.doSpecialPromotions` | boolean | `true`  | Complete special promotions |
-| `workers.doMorePromotions`    | boolean | `true`  | Complete more promotions    |
-| `workers.doPunchCards`        | boolean | `true`  | Complete punchcards         |
-| `workers.doAppPromotions`     | boolean | `true`  | Complete app promotions     |
-| `workers.doDesktopSearch`     | boolean | `true`  | Perform desktop searches    |
-| `workers.doMobileSearch`      | boolean | `true`  | Perform mobile searches     |
-| `workers.doDailyCheckIn`      | boolean | `true`  | Complete daily check-in     |
-| `workers.doReadToEarn`        | boolean | `true`  | Complete Read-to-Earn       |
+| Setting                       | Type    | Default | Description                 | Docker environment variable          |
+| ----------------------------- | ------- | ------- | --------------------------- | ------------------------------------ |
+| `workers.doDailySet`          | boolean | `true`  | Complete daily set          | `CONFIG_WORKER_DAILY_SET`            |
+| `workers.doSpecialPromotions` | boolean | `true`  | Complete special promotions | `CONFIG_WORKER_SPECIAL_PROMOTIONS`   |
+| `workers.doMorePromotions`    | boolean | `true`  | Complete more promotions    | `CONFIG_WORKER_MORE_PROMOTIONS`      |
+| `workers.doPunchCards`        | boolean | `true`  | Complete punchcards         | `CONFIG_WORKER_PUNCH_CARDS`          |
+| `workers.doAppPromotions`     | boolean | `true`  | Complete app promotions     | `CONFIG_WORKER_APP_PROMOTIONS`       |
+| `workers.doDesktopSearch`     | boolean | `true`  | Perform desktop searches    | `CONFIG_WORKER_DESKTOP_SEARCH`       |
+| `workers.doMobileSearch`      | boolean | `true`  | Perform mobile searches     | `CONFIG_WORKER_MOBILE_SEARCH`        |
+| `workers.doDailyCheckIn`      | boolean | `true`  | Complete daily check-in     | `CONFIG_WORKER_DAILY_CHECKIN`        |
+| `workers.doReadToEarn`        | boolean | `true`  | Complete Read-to-Earn       | `CONFIG_WORKER_READ_TO_EARN`         |
 
 ### Search Settings
 
-| Setting                                | Type     | Default                                      | Description                         |
-| -------------------------------------- | -------- | -------------------------------------------- | ----------------------------------- |
-| `searchSettings.scrollRandomResults`   | boolean  | `false`                                      | Scroll randomly on results          |
-| `searchSettings.clickRandomResults`    | boolean  | `false`                                      | Click random links                  |
-| `searchSettings.parallelSearching`     | boolean  | `true`                                       | Run searches in parallel            |
-| `searchSettings.queryEngines`          | string[] | `["google", "wikipedia", "reddit", "local"]` | Query engines to use                |
-| `searchSettings.searchResultVisitTime` | string   | `"10sec"`                                    | Time to spend on each search result |
-| `searchSettings.searchDelay.min`       | string   | `"30sec"`                                    | Minimum delay between searches      |
-| `searchSettings.searchDelay.max`       | string   | `"1min"`                                     | Maximum delay between searches      |
-| `searchSettings.readDelay.min`         | string   | `"30sec"`                                    | Minimum delay for reading           |
-| `searchSettings.readDelay.max`         | string   | `"1min"`                                     | Maximum delay for reading           |
+| Setting                                | Type     | Default                                      | Description                         | Docker environment variable     |
+| -------------------------------------- | -------- | -------------------------------------------- | ----------------------------------- | ------------------------------- |
+| `searchSettings.scrollRandomResults`   | boolean  | `false`                                      | Scroll randomly on results          | `CONFIG_SEARCH_SCROLL_RANDOM`   |
+| `searchSettings.clickRandomResults`    | boolean  | `false`                                      | Click random links                  | `CONFIG_SEARCH_CLICK_RANDOM`    |
+| `searchSettings.parallelSearching`     | boolean  | `true`                                       | Run searches in parallel            | `CONFIG_SEARCH_PARALLEL`        |
+| `searchSettings.queryEngines`          | string[] | `["google", "wikipedia", "reddit", "local"]` | Query engines to use                |                                 |
+| `searchSettings.searchResultVisitTime` | string   | `"10sec"`                                    | Time to spend on each search result | `CONFIG_SEARCH_VISIT_TIME`      |
+| `searchSettings.searchDelay.min`       | string   | `"30sec"`                                    | Minimum delay between searches      | `CONFIG_SEARCH_DELAY_MIN`       |
+| `searchSettings.searchDelay.max`       | string   | `"1min"`                                     | Maximum delay between searches      | `CONFIG_SEARCH_DELAY_MAX`       |
+| `searchSettings.readDelay.min`         | string   | `"30sec"`                                    | Minimum delay for reading           | `CONFIG_SEARCH_READ_DELAY_MIN`  |
+| `searchSettings.readDelay.max`         | string   | `"1min"`                                     | Maximum delay for reading           | `CONFIG_SEARCH_READ_DELAY_MAX`  |
 
 ### Logging
 
-| Setting                          | Type     | Default                | Description                       |
-| -------------------------------- | -------- | ---------------------- | --------------------------------- |
-| `debugLogs`                      | boolean  | `false`                | Enable debug logging              |
-| `consoleLogFilter.enabled`       | boolean  | `false`                | Enable console log filtering      |
-| `consoleLogFilter.mode`          | string   | `"whitelist"`          | Filter mode (whitelist/blacklist) |
-| `consoleLogFilter.levels`        | string[] | `["error", "warn"]`    | Log levels to filter              |
-| `consoleLogFilter.keywords`      | string[] | `["starting account"]` | Keywords to filter                |
-| `consoleLogFilter.regexPatterns` | string[] | `[]`                   | Regex patterns for filtering      |
+| Setting                          | Type     | Default                | Description                       | Docker environment variable   |
+| -------------------------------- | -------- | ---------------------- | --------------------------------- | ----------------------------- |
+| `debugLogs`                      | boolean  | `false`                | Enable debug logging              | `CONFIG_DEBUG_LOGS`           |
+| `consoleLogFilter.enabled`       | boolean  | `false`                | Enable console log filtering      | `CONFIG_LOG_FILTER_ENABLED`   |
+| `consoleLogFilter.mode`          | string   | `"whitelist"`          | Filter mode (whitelist/blacklist) | `CONFIG_LOG_FILTER_MODE`      |
+| `consoleLogFilter.levels`        | string[] | `["error", "warn"]`    | Log levels to filter              | `CONFIG_LOG_FILTER_LEVELS`\*  |
+| `consoleLogFilter.keywords`      | string[] | `["starting account"]` | Keywords to filter                | `CONFIG_LOG_FILTER_KEYWORDS`\*|
+| `consoleLogFilter.regexPatterns` | string[] | `[]`                   | Regex patterns for filtering      |                               |
+
+> [!NOTE]
+> \* Docker `CONFIG_*` array values are comma-separated strings e.g. `"error,warn"`
+> Regex pattenrs must be entered directly in the `config.yaml`
 
 ### Proxy
 
-| Setting             | Type    | Default | Description                 |
-| ------------------- | ------- | ------- | --------------------------- |
-| `proxy.queryEngine` | boolean | `true`  | Proxy query engine requests |
+| Setting             | Type    | Default | Description                 | Docker environment variable|
+| ------------------- | ------- | ------- | --------------------------- | -------------------------- |
+| `proxy.queryEngine` | boolean | `true`  | Proxy query engine requests | `CONFIG_PROXY_QUERY_ENGINE` |
 
 ### Webhooks
 
-| Setting                                  | Type     | Default                                              | Description                       |
-| ---------------------------------------- | -------- | ---------------------------------------------------- | --------------------------------- |
-| `webhook.discord.enabled`                | boolean  | `false`                                              | Enable Discord webhook            |
-| `webhook.discord.url`                    | string   | `""`                                                 | Discord webhook URL               |
-| `webhook.ntfy.enabled`                   | boolean  | `false`                                              | Enable ntfy notifications         |
-| `webhook.ntfy.url`                       | string   | `""`                                                 | ntfy server URL                   |
-| `webhook.ntfy.topic`                     | string   | `""`                                                 | ntfy topic                        |
-| `webhook.ntfy.token`                     | string   | `""`                                                 | ntfy authentication token         |
-| `webhook.ntfy.title`                     | string   | `"Microsoft-Rewards-Script"`                         | Notification title                |
-| `webhook.ntfy.tags`                      | string[] | `["bot", "notify"]`                                  | Notification tags                 |
-| `webhook.ntfy.priority`                  | number   | `3`                                                  | Notification priority (1-5)       |
-| `webhook.webhookLogFilter.enabled`       | boolean  | `false`                                              | Enable webhook log filtering      |
-| `webhook.webhookLogFilter.mode`          | string   | `"whitelist"`                                        | Filter mode (whitelist/blacklist) |
-| `webhook.webhookLogFilter.levels`        | string[] | `["error"]`                                          | Log levels to send                |
-| `webhook.webhookLogFilter.keywords`      | string[] | `["starting account", "select number", "collected"]` | Keywords to filter                |
-| `webhook.webhookLogFilter.regexPatterns` | string[] | `[]`                                                 | Regex patterns for filtering      |
+| Setting                                  | Type     | Default                                              | Description                       | Docker environment variable              |
+| ---------------------------------------- | -------- | ---------------------------------------------------- | --------------------------------- | ---------------------------------------- |
+| `webhook.discord.enabled`                | boolean  | `false`                                              | Enable Discord webhook            | `CONFIG_DISCORD_ENABLED`                 |
+| `webhook.discord.url`                    | string   | `""`                                                 | Discord webhook URL               | `CONFIG_DISCORD_URL`                     |
+| `webhook.ntfy.enabled`                   | boolean  | `false`                                              | Enable ntfy notifications         | `CONFIG_NTFY_ENABLED`                    |
+| `webhook.ntfy.url`                       | string   | `""`                                                 | ntfy server URL                   | `CONFIG_NTFY_URL`                        |
+| `webhook.ntfy.topic`                     | string   | `""`                                                 | ntfy topic                        | `CONFIG_NTFY_TOPIC`                      |
+| `webhook.ntfy.token`                     | string   | `""`                                                 | ntfy authentication token         | `CONFIG_NTFY_TOKEN`                      |
+| `webhook.ntfy.title`                     | string   | `"Microsoft-Rewards-Script"`                         | Notification title                | `CONFIG_NTFY_TITLE`                      |
+| `webhook.ntfy.tags`                      | string[] | `["bot", "notify"]`                                  | Notification tags                 | `CONFIG_NTFY_TAGS` \*                    |
+| `webhook.ntfy.priority`                  | number   | `3`                                                  | Notification priority (1-5)       | `CONFIG_NTFY_PRIORITY`                   |
+| `webhook.webhookLogFilter.enabled`       | boolean  | `false`                                              | Enable webhook log filtering      | `CONFIG_WEBHOOK_LOG_FILTER_ENABLED`      |
+| `webhook.webhookLogFilter.mode`          | string   | `"whitelist"`                                        | Filter mode (whitelist/blacklist) | `CONFIG_WEBHOOK_LOG_FILTER_MODE`         |
+| `webhook.webhookLogFilter.levels`        | string[] | `["error"]`                                          | Log levels to send                | `CONFIG_WEBHOOK_LOG_FILTER_LEVELS` \*    |
+| `webhook.webhookLogFilter.keywords`      | string[] | `["starting account", "select number", "collected"]` | Keywords to filter                | `CONFIG_WEBHOOK_LOG_FILTER_KEYWORDS` \*  |
+| `webhook.webhookLogFilter.regexPatterns` | string[] | `[]`                                                 | Regex patterns for filtering      |                                          |
+
+> [!NOTE]
+> \* Docker `CONFIG_*` array values are comma-separated strings e.g. `"error,warn"`
+> Regex pattenrs must be entered directly in the `config.yaml`
 
 > [!WARNING]
 > **NTFY** users set the `webhookLogFilter` to `enabled`, or you will receive push notifications for _all_ logs.
-> When enabled, only account start, 2FA codes, and account completion summaries are delivered as push notifcations.
+> When enabled, only account start, 2FA codes, and account completion summaries are delivered as push notifications.
 > Customize which notifications you receive with the `keywords` options.
 
 ---
@@ -182,6 +190,10 @@ Edit `src/config.json` to customize behavior. Below are all currently available 
 ## Account Setup
 
 Edit `src/accounts.json`.
+
+> [!TIP]
+> Docker users can set account details directly in the `compose.yaml`, using a `.env` is recommended for sensitive information.
+> Docker will automatically create a valid `accounts.json` on container creation, and save the file in `./config/`
 
 > [!WARNING]
 > The file is a **flat array** of accounts, not `{ "accounts": [ ... ] }`.

--- a/README.md
+++ b/README.md
@@ -23,10 +23,13 @@
 
 ## Quick Setup
 
+### Bare metal
+
 **Requirements:** Node.js >= 24 and Git  
 Works on Windows, Linux, macOS, and WSL.
 
-### Get the script
+#### Get the script
+
 ```bash
 git clone https://github.com/TheNetsky/Microsoft-Rewards-Script.git
 cd Microsoft-Rewards-Script
@@ -34,43 +37,47 @@ cd Microsoft-Rewards-Script
 
 Or, download the latest release ZIP and extract it.
 
-> [!TIP]
-> **Docker users:** optionally skip the clone step when using the prebuilt image. You only need a valid `accounts.json` and `config.json` locally. They can be placed anywhere. 
-> Update the `volumes` section in [`compose.yaml`](./compose.yaml) to point to your files (e.g., `/your/path/to/accounts.json:/usr/src/microsoft-rewards-script/dist/accounts.json:ro`).
-
-### Create accounts.json and config.json
+#### Create an account.json and config.json
 
 Copy, rename, and edit your account and configuration files before deploying the script.
 
 - Copy or rename `src/accounts.example.json` to `src/accounts.json` and add your credentials
-- Copy or rename `src/config.example.json` to `src/config.json` and customize your preferences
+- Copy or rename `src/config.example.json` to `src/config.json` and customize your preferences.
 
 > [!CAUTION]
 > Do not skip this step.
-> Prior versions of accounts.json and config.json are not compatible with the current release.
+> Prior versions of accounts.json and config.json are not compatible with current release.
 
 > [!WARNING]
 > You must rebuild your script after making any changes to accounts.json and config.json.
 
-### Build and run the script (bare metal)
+#### Build and run the script (bare metal version)
+
 ```bash
 npm run pre-build
 npm run build
 npm run start
 ```
 
-### Build and run the script (Docker)
+### Docker
+- Copy the sample [`compose.yaml`](compose.yaml)
+- Copy and rename [`env.example`](env.example)to `.env` and add your account credentials:
+```env
+ACCOUNT_1_EMAIL=you@example.com
+ACCOUNT_1_PASSWORD=your_password
+```
+- Optionally, review `compose.yaml` to adjust scheduling, timezone, and config options such as webhooks. Then start the container:
 ```bash
 docker compose up -d
 ```
-
 > [!CAUTION]
-> Set `headless` to `true` in `src/config.json` when using Docker.
-> Additional Docker-specific scheduling options are in `compose.yaml`.
+> A `config.json` is generated automatically on first run with sensible defaults.
+> To customise it, edit `./config/config.json` directly or set `CONFIG_*` variables in `compose.yaml`.
+> If a new image version adds config options you're missing, a warning will appear in the container logs.
 
 > [!TIP]
-> When headless, monitor logs with `docker logs microsoft-rewards-script` (for example, to view passwordless codes), or enable a webhook service in `src/config.json`.
-
+> Monitor logs with `docker logs microsoft-rewards-script`, useful for viewing passwordless login codes or diagnosing issues. 
+> You can also enable a webhook in `compose.yaml` for notifications.
 ---
 
 ## Nix Setup

--- a/README.md
+++ b/README.md
@@ -61,19 +61,27 @@ npm run start
 
 ### Docker
 - Copy the sample [`compose.yaml`](compose.yaml)
-- Copy and rename [`env.example`](env.example)to `.env` and add your account credentials:
+- Copy and rename [`env.example`](env.example) to `.env` and add your account credentials:
 ```env
 ACCOUNT_1_EMAIL=you@example.com
 ACCOUNT_1_PASSWORD=your_password
 ```
-- Optionally, review `compose.yaml` to adjust scheduling, timezone, and config options such as webhooks. Then start the container:
-```bash
-docker compose up -d
-```
-> [!CAUTION]
-> A `config.json` is generated automatically on first run with sensible defaults.
-> To customise it, edit `./config/config.json` directly or set `CONFIG_*` variables in `compose.yaml`.
-> If a new image version adds config options you're missing, a warning will appear in the container logs.
+> [!NOTE]
+> A valid `accounts.json` is automatically created based on these values, and saved locally to `./config/`
+
+- Review `compose.yaml` to adjust scheduling, timezone, and config options. 
+
+> [!NOTE]
+> A valid `config.json` is auto-generated on first run using default values, and saved locally to `./config/`. 
+> Optionally, use `CONFIG_*` variables in the `environment:` section of the `compose.yaml` to customise your options (e.g., clusters, webhook). 
+> Commonly changed values are included in the sample `compose.yaml`, and a full list of configuration options are in [the table below](#configuration-options). 
+> Custom config values set in the `compose.yaml` are applied on every startup and always take precedence over `./config/config.json`.
+
+> [!TIP]
+> If a new image adds config options you're missing, a warning will appear in the container logs.
+> To update, delete `./config/config.json` and restart, a fresh one will be generated from the latest example, with your `compose.yaml` overrides re-applied.
+
+- Start the container: `docker compose up -d`
 
 > [!TIP]
 > Monitor logs with `docker logs microsoft-rewards-script`, useful for viewing passwordless login codes or diagnosing issues. 
@@ -92,9 +100,6 @@ Edit `config.json` to customize behavior, or set `CONFIG_*` environment variable
 
 > [!WARNING]
 > Rebuild the script (bare metal), or recreate the container (Docker) after all config changes.
-
-> [!NOTE]
-> Docker: `CONFIG_*` variables are applied on every startup and always take precedence over `./config/config.json`. See `compose.yaml` for common options, and all available keys are listed below.
 
 ### Core
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,26 +1,18 @@
 services:
     microsoft-rewards-script:
         #image: ghcr.io/thenetsky/microsoft-rewards-script:latest
-        build: . #dev: must be built locally for testing
+        build: . #dev note: must be built locally for testing
         container_name: microsoft-rewards-script
         restart: unless-stopped
 
         # ── Volumes ──────────────────────────────────────────────────────────
-        # Files in ./config/ are mapped into the container at their expected paths.
-        # On first run, config.json is generated from config.example.json and
-        # accounts.json is generated from ACCOUNT_* env vars — both written into
-        # ./config/ so they persist and are visible locally. Edit either file
-        # freely; the container will never overwrite them, but will warn in the
-        # logs if a new image version adds config keys you're missing.
+        # A valid config.json and accounts.json are auto-generated into ./config/ on first run.
         volumes:
             - ./config:/usr/src/microsoft-rewards-script/dist/config
             - ./sessions:/usr/src/microsoft-rewards-script/dist/browser/sessions
 
         # ── Accounts ─────────────────────────────────────────────────────────
-        # Credentials are recommended to be set in .env (loaded automatically).
-        # Only ACCOUNT_1_EMAIL and ACCOUNT_1_PASSWORD are required — all other
-        # fields are optional and fall back to defaults from accounts.example.json.
-        # Accounts can also be set directly in the environment block below.
+        # Account credentials are loaded from .env, see env.example. At minimum an ACCOUNT_1_EMAIL and ACCOUNT_1_PASSWORD are required.
         env_file:
             - .env
 
@@ -33,55 +25,23 @@ services:
             SKIP_RANDOM_SLEEP: 'false'
             #MIN_SLEEP_MINUTES: "5"
             #MAX_SLEEP_MINUTES: "50"
-            #STUCK_PROCESS_TIMEOUT_HOURS: "8"
+            #STUCK_PROCESS_TIMEOUT_HOURS: "8"  
 
             # ── Accounts (optional override) ──────────────────────────────────
-            # Account are normally set in .env — only use these if you want to
-            # hardcode an account directly in the compose, e.g. for testing.
+            # Account credentials can be set here directly instead of .env, remove the env_file block above if doing so
             #ACCOUNT_1_EMAIL: you@example.com
             #ACCOUNT_1_PASSWORD: your_password
 
             # ── Config overrides ──────────────────────────────────────────────
-            # These patch config.json at every startup. Defaults come from
-            # config.example.json — only set what you want to change.
-            # headless is always forced true in Docker and cannot be changed.
-            #
+            # Common config options — uncomment and set only what you want to change from default
+            # A full list of available CONFIG_* options are in the README.
+            # 
             # General:
             #CONFIG_CLUSTERS: '1'
-            #CONFIG_DEBUG_LOGS: 'false'
-            #CONFIG_ERROR_DIAGNOSTICS: 'false'
-            #CONFIG_GLOBAL_TIMEOUT: '30sec'
-            #CONFIG_SEARCH_ON_BING_LOCAL: 'false'
-            #
-            # Workers (set to 'false' to disable):
-            #CONFIG_WORKER_DAILY_SET: 'true'
-            #CONFIG_WORKER_SPECIAL_PROMOTIONS: 'true'
-            #CONFIG_WORKER_MORE_PROMOTIONS: 'true'
-            #CONFIG_WORKER_PUNCH_CARDS: 'true'
-            #CONFIG_WORKER_APP_PROMOTIONS: 'true'
-            #CONFIG_WORKER_DESKTOP_SEARCH: 'true'
-            #CONFIG_WORKER_MOBILE_SEARCH: 'true'
-            #CONFIG_WORKER_DAILY_CHECKIN: 'true'
-            #CONFIG_WORKER_READ_TO_EARN: 'true'
             #
             # Search behaviour:
-            #CONFIG_SEARCH_PARALLEL: 'true'
             #CONFIG_SEARCH_DELAY_MIN: '30sec'
             #CONFIG_SEARCH_DELAY_MAX: '1min'
-            #CONFIG_SEARCH_READ_DELAY_MIN: '30sec'
-            #CONFIG_SEARCH_READ_DELAY_MAX: '1min'
-            #CONFIG_SEARCH_VISIT_TIME: '10sec'
-            #CONFIG_SEARCH_SCROLL_RANDOM: 'false'
-            #CONFIG_SEARCH_CLICK_RANDOM: 'false'
-            #
-            # Proxy:
-            #CONFIG_PROXY_QUERY_ENGINE: 'true'
-            #
-            # Console log filter:
-            #CONFIG_LOG_FILTER_ENABLED: 'false'
-            #CONFIG_LOG_FILTER_MODE: 'whitelist'       # whitelist or blacklist
-            #CONFIG_LOG_FILTER_LEVELS: 'error,warn'    # comma-separated
-            #CONFIG_LOG_FILTER_KEYWORDS: 'starting account' # comma-separated
             #
             # Discord webhook:
             #CONFIG_DISCORD_ENABLED: 'true'
@@ -95,13 +55,12 @@ services:
             #CONFIG_NTFY_TITLE: 'Microsoft-Rewards-Script'
             #CONFIG_NTFY_PRIORITY: '3'
             #
-            # Webhook log filter (controls which events trigger webhook notifications):
+            # Webhook log filter (controls which events trigger webhook notifications, enable when using NTFY):
             #CONFIG_WEBHOOK_LOG_FILTER_ENABLED: 'false'
             #CONFIG_WEBHOOK_LOG_FILTER_MODE: 'whitelist'      # whitelist or blacklist
             #CONFIG_WEBHOOK_LOG_FILTER_LEVELS: 'error'        # comma-separated
             #CONFIG_WEBHOOK_LOG_FILTER_KEYWORDS: 'starting account,select number,collected'
-            
-        # Health check: ensures cron is running, container marked unhealthy if cron stops
+
         healthcheck:
             test: ['CMD', 'sh', '-c', 'pgrep cron > /dev/null || exit 1']
             interval: 60s
@@ -109,10 +68,5 @@ services:
             retries: 3
             start_period: 30s
 
-        # Dev: set container memory limits to prevent crashes during testing
-        mem_limit: 3g
-        memswap_limit: 4g   # 3g RAM + 1g swap
-        
-        # Security hardening
         security_opt:
             - no-new-privileges:true

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,40 +1,42 @@
 services:
     microsoft-rewards-script:
-        #image: ghcr.io/thenetsky/microsoft-rewards-script:latest
-        build: . #dev note: must be built locally for testing
+        image: ghcr.io/thenetsky/microsoft-rewards-script:latest
         container_name: microsoft-rewards-script
         restart: unless-stopped
-
-        # ── Volumes ──────────────────────────────────────────────────────────
-        # A valid config.json and accounts.json are auto-generated into ./config/ on first run.
         volumes:
             - ./config:/usr/src/microsoft-rewards-script/dist/config
             - ./sessions:/usr/src/microsoft-rewards-script/dist/browser/sessions
-
-        # ── Accounts ─────────────────────────────────────────────────────────
-        # Account credentials are loaded from .env, see env.example. At minimum an ACCOUNT_1_EMAIL and ACCOUNT_1_PASSWORD are required.
-        env_file:
-            - .env
-
         environment:
+
             # ── Scheduling ───────────────────────────────────────────────────
             TZ: 'America/Toronto'
             NODE_ENV: 'production'
-            CRON_SCHEDULE: '0 7 * * *'   # use crontab.guru to build your schedule
-            RUN_ON_START: 'true'          # run immediately on container start
+            CRON_SCHEDULE: '0 7 * * *'   # use crontab.guru to customize your schedule
+            RUN_ON_START: 'true'          # run script immediately on container start
             SKIP_RANDOM_SLEEP: 'false'
             #MIN_SLEEP_MINUTES: "5"
             #MAX_SLEEP_MINUTES: "50"
             #STUCK_PROCESS_TIMEOUT_HOURS: "8"  
 
-            # ── Accounts (optional override) ──────────────────────────────────
-            # Account credentials can be set here directly instead of .env, remove the env_file block above if doing so
-            #ACCOUNT_1_EMAIL: you@example.com
-            #ACCOUNT_1_PASSWORD: your_password
+            # ── Accounts ─────────────────────────────────────────────────────
+            ACCOUNT_1_EMAIL: ${ACCOUNT_1_EMAIL}
+            ACCOUNT_1_PASSWORD: ${ACCOUNT_1_PASSWORD}
+            #ACCOUNT_1_TOTP_SECRET: ${ACCOUNT_1_TOTP_SECRET}
+            #ACCOUNT_1_RECOVERY_EMAIL: ${ACCOUNT_1_RECOVERY_EMAIL}
+            #ACCOUNT_1_GEO_LOCALE: ${ACCOUNT_1_GEO_LOCALE}
+            #ACCOUNT_1_LANG_CODE: ${ACCOUNT_1_LANG_CODE}
+            #ACCOUNT_1_PROXY_AXIOS: ${ACCOUNT_1_PROXY_AXIOS}
+            #ACCOUNT_1_PROXY_URL: ${ACCOUNT_1_PROXY_URL}
+            #ACCOUNT_1_PROXY_PORT: ${ACCOUNT_1_PROXY_PORT}
+            #ACCOUNT_1_PROXY_USERNAME: ${ACCOUNT_1_PROXY_USERNAME}
+            #ACCOUNT_1_PROXY_PASSWORD: ${ACCOUNT_1_PROXY_PASSWORD}
+            #
+            #ACCOUNT_2_EMAIL: ${ACCOUNT_2_EMAIL}
+            #ACCOUNT_2_PASSWORD: ${ACCOUNT_2_PASSWORD}
+            # Add additional accounts as ACCOUNT_3_*, ACCOUNT_4_*, etc. following the same pattern
 
-            # ── Config overrides ──────────────────────────────────────────────
-            # Common config options — uncomment and set only what you want to change from default
-            # A full list of available CONFIG_* options are in the README.
+            # ── Configuration ───────────────────────────────────────────────
+            # Uncomment to override defaults, a full list of configuration options are in the README.
             # 
             # General:
             #CONFIG_CLUSTERS: '1'

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,25 +1,106 @@
 services:
     microsoft-rewards-script:
-        image: ghcr.io/thenetsky/microsoft-rewards-script:latest
+        #image: ghcr.io/thenetsky/microsoft-rewards-script:latest
+        build: . #dev: must be built locally for testing
         container_name: microsoft-rewards-script
         restart: unless-stopped
-        # Create and customize your accounts.json and config.json prior to deploying the container (default location: /src/)
-        # Default paths assume you've cloned the repo. Advanced users can point to files anywhere on their system.
+
+        # ── Volumes ──────────────────────────────────────────────────────────
+        # Files in ./config/ are mapped into the container at their expected paths.
+        # On first run, config.json is generated from config.example.json and
+        # accounts.json is generated from ACCOUNT_* env vars — both written into
+        # ./config/ so they persist and are visible locally. Edit either file
+        # freely; the container will never overwrite them, but will warn in the
+        # logs if a new image version adds config keys you're missing.
         volumes:
-            - ./src/accounts.json:/usr/src/microsoft-rewards-script/dist/accounts.json:ro
-            - ./src/config.json:/usr/src/microsoft-rewards-script/dist/config.json:ro
+            - ./config:/usr/src/microsoft-rewards-script/dist/config
             - ./sessions:/usr/src/microsoft-rewards-script/dist/browser/sessions
+
+        # ── Accounts ─────────────────────────────────────────────────────────
+        # Credentials are recommended to be set in .env (loaded automatically).
+        # Only ACCOUNT_1_EMAIL and ACCOUNT_1_PASSWORD are required — all other
+        # fields are optional and fall back to defaults from accounts.example.json.
+        # Accounts can also be set directly in the environment block below.
+        env_file:
+            - .env
+
         environment:
-            TZ: 'America/Toronto' # Set your timezone for proper scheduling
+            # ── Scheduling ───────────────────────────────────────────────────
+            TZ: 'America/Toronto'
             NODE_ENV: 'production'
-            CRON_SCHEDULE: '0 7 * * *' # Customize your schedule, use crontab.guru for formatting
-            RUN_ON_START: 'true' # Runs the script immediately on container startup
-            # Add a small random delay to the scheduled start time (uncomment to customize delay, or disable)
+            CRON_SCHEDULE: '0 7 * * *'   # use crontab.guru to build your schedule
+            RUN_ON_START: 'true'          # run immediately on container start
+            SKIP_RANDOM_SLEEP: 'false'
             #MIN_SLEEP_MINUTES: "5"
             #MAX_SLEEP_MINUTES: "50"
-            SKIP_RANDOM_SLEEP: 'false'
-            # Set a timeout for stuck script runs (default: 8h, uncomment to customize)
             #STUCK_PROCESS_TIMEOUT_HOURS: "8"
+
+            # ── Accounts (optional override) ──────────────────────────────────
+            # Account are normally set in .env — only use these if you want to
+            # hardcode an account directly in the compose, e.g. for testing.
+            #ACCOUNT_1_EMAIL: you@example.com
+            #ACCOUNT_1_PASSWORD: your_password
+
+            # ── Config overrides ──────────────────────────────────────────────
+            # These patch config.json at every startup. Defaults come from
+            # config.example.json — only set what you want to change.
+            # headless is always forced true in Docker and cannot be changed.
+            #
+            # General:
+            #CONFIG_CLUSTERS: '1'
+            #CONFIG_DEBUG_LOGS: 'false'
+            #CONFIG_ERROR_DIAGNOSTICS: 'false'
+            #CONFIG_GLOBAL_TIMEOUT: '30sec'
+            #CONFIG_SEARCH_ON_BING_LOCAL: 'false'
+            #
+            # Workers (set to 'false' to disable):
+            #CONFIG_WORKER_DAILY_SET: 'true'
+            #CONFIG_WORKER_SPECIAL_PROMOTIONS: 'true'
+            #CONFIG_WORKER_MORE_PROMOTIONS: 'true'
+            #CONFIG_WORKER_PUNCH_CARDS: 'true'
+            #CONFIG_WORKER_APP_PROMOTIONS: 'true'
+            #CONFIG_WORKER_DESKTOP_SEARCH: 'true'
+            #CONFIG_WORKER_MOBILE_SEARCH: 'true'
+            #CONFIG_WORKER_DAILY_CHECKIN: 'true'
+            #CONFIG_WORKER_READ_TO_EARN: 'true'
+            #
+            # Search behaviour:
+            #CONFIG_SEARCH_PARALLEL: 'true'
+            #CONFIG_SEARCH_DELAY_MIN: '30sec'
+            #CONFIG_SEARCH_DELAY_MAX: '1min'
+            #CONFIG_SEARCH_READ_DELAY_MIN: '30sec'
+            #CONFIG_SEARCH_READ_DELAY_MAX: '1min'
+            #CONFIG_SEARCH_VISIT_TIME: '10sec'
+            #CONFIG_SEARCH_SCROLL_RANDOM: 'false'
+            #CONFIG_SEARCH_CLICK_RANDOM: 'false'
+            #
+            # Proxy:
+            #CONFIG_PROXY_QUERY_ENGINE: 'true'
+            #
+            # Console log filter:
+            #CONFIG_LOG_FILTER_ENABLED: 'false'
+            #CONFIG_LOG_FILTER_MODE: 'whitelist'       # whitelist or blacklist
+            #CONFIG_LOG_FILTER_LEVELS: 'error,warn'    # comma-separated
+            #CONFIG_LOG_FILTER_KEYWORDS: 'starting account' # comma-separated
+            #
+            # Discord webhook:
+            #CONFIG_DISCORD_ENABLED: 'true'
+            #CONFIG_DISCORD_URL: 'https://discord.com/api/webhooks/...'
+            #
+            # ntfy webhook:
+            #CONFIG_NTFY_ENABLED: 'true'
+            #CONFIG_NTFY_URL: 'https://ntfy.sh'
+            #CONFIG_NTFY_TOPIC: 'my-rewards-alerts'
+            #CONFIG_NTFY_TOKEN: ''
+            #CONFIG_NTFY_TITLE: 'Microsoft-Rewards-Script'
+            #CONFIG_NTFY_PRIORITY: '3'
+            #
+            # Webhook log filter (controls which events trigger webhook notifications):
+            #CONFIG_WEBHOOK_LOG_FILTER_ENABLED: 'false'
+            #CONFIG_WEBHOOK_LOG_FILTER_MODE: 'whitelist'      # whitelist or blacklist
+            #CONFIG_WEBHOOK_LOG_FILTER_LEVELS: 'error'        # comma-separated
+            #CONFIG_WEBHOOK_LOG_FILTER_KEYWORDS: 'starting account,select number,collected'
+            
         # Health check: ensures cron is running, container marked unhealthy if cron stops
         healthcheck:
             test: ['CMD', 'sh', '-c', 'pgrep cron > /dev/null || exit 1']
@@ -27,6 +108,11 @@ services:
             timeout: 10s
             retries: 3
             start_period: 30s
+
+        # Dev: set container memory limits to prevent crashes during testing
+        mem_limit: 3g
+        memswap_limit: 4g   # 3g RAM + 1g swap
+        
         # Security hardening
         security_opt:
             - no-new-privileges:true

--- a/env.example
+++ b/env.example
@@ -1,0 +1,32 @@
+# Microsoft Rewards Script — Account Credentials
+# Copy this file to .env and fill in your details.
+# .env should be in your .gitignore — never commit your credentials.
+#
+# Add one numbered block per account starting at 1.
+# The script stops looking at the first missing ACCOUNT_N_EMAIL.
+
+# Account 1
+ACCOUNT_1_EMAIL=you@example.com
+ACCOUNT_1_PASSWORD=your_password
+#ACCOUNT_1_TOTP_SECRET=
+#ACCOUNT_1_RECOVERY_EMAIL=
+#ACCOUNT_1_GEO_LOCALE=auto
+#ACCOUNT_1_LANG_CODE=en
+#ACCOUNT_1_PROXY_AXIOS=false
+#ACCOUNT_1_PROXY_URL=
+#ACCOUNT_1_PROXY_PORT=0
+#ACCOUNT_1_PROXY_USERNAME=
+#ACCOUNT_1_PROXY_PASSWORD=
+
+# Account 2 (optional, duplicate block and increment for more)
+#ACCOUNT_2_EMAIL=second@example.com
+#ACCOUNT_2_PASSWORD=your_password
+#ACCOUNT_2_TOTP_SECRET=
+#ACCOUNT_2_RECOVERY_EMAIL=
+#ACCOUNT_2_GEO_LOCALE=auto
+#ACCOUNT_2_LANG_CODE=en
+#ACCOUNT_2_PROXY_AXIOS=false
+#ACCOUNT_2_PROXY_URL=
+#ACCOUNT_2_PROXY_PORT=0
+#ACCOUNT_2_PROXY_USERNAME=
+#ACCOUNT_2_PROXY_PASSWORD=

--- a/scripts/docker/entrypoint.sh
+++ b/scripts/docker/entrypoint.sh
@@ -4,41 +4,353 @@ set -euo pipefail
 # Ensure Playwright uses preinstalled browsers
 export PLAYWRIGHT_BROWSERS_PATH=0
 
+SCRIPT_DIR="/usr/src/microsoft-rewards-script"
+DIST_DIR="$SCRIPT_DIR/dist"
+
+# ─────────────────────────────────────────────────────────────────────────────
 # 1. Timezone: default to UTC if not provided
+# ─────────────────────────────────────────────────────────────────────────────
 : "${TZ:=UTC}"
 ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime
 echo "$TZ" > /etc/timezone
 dpkg-reconfigure -f noninteractive tzdata
 
+# ─────────────────────────────────────────────────────────────────────────────
 # 2. Validate CRON_SCHEDULE
+# ─────────────────────────────────────────────────────────────────────────────
 if [ -z "${CRON_SCHEDULE:-}" ]; then
   echo "ERROR: CRON_SCHEDULE environment variable is not set." >&2
   echo "Please set CRON_SCHEDULE (e.g., \"0 2 * * *\")." >&2
   exit 1
 fi
 
-# 3. Initial run without sleep if RUN_ON_START=true
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. Accounts: generate accounts.json from ACCOUNT_N_* env vars
+#
+#    Add one numbered block per account in .env, starting at 1:
+#      ACCOUNT_1_EMAIL, ACCOUNT_1_PASSWORD, ...
+#      ACCOUNT_2_EMAIL, ACCOUNT_2_PASSWORD, ...
+#
+#    All fields match accounts.example.json exactly.
+#    The loop stops at the first missing ACCOUNT_N_EMAIL.
+# ─────────────────────────────────────────────────────────────────────────────
+CONFIG_DIR="$DIST_DIR/config"
+mkdir -p "$CONFIG_DIR"
+
+ACCOUNTS_FILE="$CONFIG_DIR/accounts.json"
+
+_build_account_json() {
+  local email="$1"
+  local password="$2"
+  local totp="${3:-}"
+  local recovery="${4:-}"
+  local geo="${5:-auto}"
+  local lang="${6:-en}"
+  local proxy_axios="${7:-false}"
+  local proxy_url="${8:-}"
+  local proxy_port="${9:-0}"
+  local proxy_user="${10:-}"
+  local proxy_pass="${11:-}"
+
+  jq -n \
+    --arg email "$email" \
+    --arg password "$password" \
+    --arg totp "$totp" \
+    --arg recovery "$recovery" \
+    --arg geo "$geo" \
+    --arg lang "$lang" \
+    --argjson proxyAxios "$proxy_axios" \
+    --arg proxyUrl "$proxy_url" \
+    --argjson proxyPort "$proxy_port" \
+    --arg proxyUser "$proxy_user" \
+    --arg proxyPass "$proxy_pass" \
+    '{
+      email: $email,
+      password: $password,
+      totpSecret: $totp,
+      recoveryEmail: $recovery,
+      geoLocale: $geo,
+      langCode: $lang,
+      proxy: {
+        proxyAxios: $proxyAxios,
+        url: $proxyUrl,
+        port: $proxyPort,
+        username: $proxyUser,
+        password: $proxyPass
+      },
+      saveFingerprint: {
+        mobile: false,
+        desktop: false
+      }
+    }'
+}
+
+account_array="[]"
+i=1
+while true; do
+  email_var="ACCOUNT_${i}_EMAIL"
+  pass_var="ACCOUNT_${i}_PASSWORD"
+  email="${!email_var:-}"
+  [ -z "$email" ] && break
+  pass="${!pass_var:?ERROR: ${pass_var} must be set when ${email_var} is set}"
+
+  totp_var="ACCOUNT_${i}_TOTP_SECRET";      totp="${!totp_var:-}"
+  rec_var="ACCOUNT_${i}_RECOVERY_EMAIL";    rec="${!rec_var:-}"
+  geo_var="ACCOUNT_${i}_GEO_LOCALE";        geo="${!geo_var:-auto}"
+  lang_var="ACCOUNT_${i}_LANG_CODE";        lang="${!lang_var:-en}"
+  paxios_var="ACCOUNT_${i}_PROXY_AXIOS";    paxios="${!paxios_var:-false}"
+  purl_var="ACCOUNT_${i}_PROXY_URL";        purl="${!purl_var:-}"
+  pport_var="ACCOUNT_${i}_PROXY_PORT";      pport="${!pport_var:-0}"
+  puser_var="ACCOUNT_${i}_PROXY_USERNAME";  puser="${!puser_var:-}"
+  ppass_var="ACCOUNT_${i}_PROXY_PASSWORD";  ppass="${!ppass_var:-}"
+
+  account_json=$(_build_account_json "$email" "$pass" "$totp" "$rec" "$geo" "$lang" "$paxios" "$purl" "$pport" "$puser" "$ppass")
+  account_array=$(echo "$account_array" | jq ". + [$account_json]")
+  i=$((i + 1))
+done
+
+if [ "$(echo "$account_array" | jq 'length')" -gt 0 ]; then
+  echo "$account_array" > "$ACCOUNTS_FILE"
+  echo "[entrypoint] accounts.json written with $(echo "$account_array" | jq 'length') account(s)"
+else
+  echo "WARNING: No ACCOUNT_1_EMAIL found. accounts.json not written — script will likely fail." >&2
+  echo "         Set ACCOUNT_1_EMAIL and ACCOUNT_1_PASSWORD in your .env file." >&2
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 4. Config: generate and patch config.json
+#
+#    Behaviour:
+#      - No config.json       → copy config.example.json as starting point
+#      - config.json exists   → use as-is (whether user-edited or previously
+#                               generated); CONFIG_* overrides always applied
+#      - Schema drift         → warn with list of missing keys in both cases;
+#                               never auto-modify the file
+#
+#    headless is always forced true — it is not optional in Docker.
+#
+#    CONFIG_* env var overrides (applied on every startup):
+#
+#    General:
+#      CONFIG_CLUSTERS=2                 → .clusters
+#      CONFIG_DEBUG_LOGS=true            → .debugLogs
+#      CONFIG_ERROR_DIAGNOSTICS=true     → .errorDiagnostics
+#      CONFIG_GLOBAL_TIMEOUT=30sec       → .globalTimeout
+#
+#    Workers (boolean):
+#      CONFIG_WORKER_DAILY_SET           → .workers.doDailySet
+#      CONFIG_WORKER_SPECIAL_PROMOTIONS  → .workers.doSpecialPromotions
+#      CONFIG_WORKER_MORE_PROMOTIONS     → .workers.doMorePromotions
+#      CONFIG_WORKER_PUNCH_CARDS         → .workers.doPunchCards
+#      CONFIG_WORKER_APP_PROMOTIONS      → .workers.doAppPromotions
+#      CONFIG_WORKER_DESKTOP_SEARCH      → .workers.doDesktopSearch
+#      CONFIG_WORKER_MOBILE_SEARCH       → .workers.doMobileSearch
+#      CONFIG_WORKER_DAILY_CHECKIN       → .workers.doDailyCheckIn
+#      CONFIG_WORKER_READ_TO_EARN        → .workers.doReadToEarn
+#
+#    Search settings:
+#      CONFIG_SEARCH_SCROLL_RANDOM       → .searchSettings.scrollRandomResults
+#      CONFIG_SEARCH_CLICK_RANDOM        → .searchSettings.clickRandomResults
+#      CONFIG_SEARCH_PARALLEL            → .searchSettings.parallelSearching
+#      CONFIG_SEARCH_DELAY_MIN           → .searchSettings.searchDelay.min
+#      CONFIG_SEARCH_DELAY_MAX           → .searchSettings.searchDelay.max
+#      CONFIG_SEARCH_READ_DELAY_MIN      → .searchSettings.readDelay.min
+#      CONFIG_SEARCH_READ_DELAY_MAX      → .searchSettings.readDelay.max
+#      CONFIG_SEARCH_VISIT_TIME          → .searchSettings.searchResultVisitTime
+#      CONFIG_SEARCH_ON_BING_LOCAL       → .searchOnBingLocalQueries
+#
+#    Proxy:
+#      CONFIG_PROXY_QUERY_ENGINE         → .proxy.queryEngine
+#
+#    Console log filter:
+#      CONFIG_LOG_FILTER_ENABLED         → .consoleLogFilter.enabled
+#      CONFIG_LOG_FILTER_MODE            → .consoleLogFilter.mode (whitelist|blacklist)
+#      CONFIG_LOG_FILTER_LEVELS          → .consoleLogFilter.levels (comma-separated)
+#      CONFIG_LOG_FILTER_KEYWORDS        → .consoleLogFilter.keywords (comma-separated)
+#
+#    Webhooks:
+#      CONFIG_DISCORD_ENABLED / CONFIG_DISCORD_URL
+#      CONFIG_NTFY_ENABLED / CONFIG_NTFY_URL / CONFIG_NTFY_TOPIC / CONFIG_NTFY_TOKEN
+#      CONFIG_NTFY_TITLE / CONFIG_NTFY_PRIORITY
+#      CONFIG_NTFY_TAGS                  → comma-separated e.g. "bot,notify"
+#
+#    Webhook log filter:
+#      CONFIG_WEBHOOK_LOG_FILTER_ENABLED  → .webhook.webhookLogFilter.enabled
+#      CONFIG_WEBHOOK_LOG_FILTER_MODE     → .webhook.webhookLogFilter.mode
+#      CONFIG_WEBHOOK_LOG_FILTER_LEVELS   → comma-separated
+#      CONFIG_WEBHOOK_LOG_FILTER_KEYWORDS → comma-separated
+#
+# ─────────────────────────────────────────────────────────────────────────────
+CONFIG_FILE="$CONFIG_DIR/config.json"
+CONFIG_EXAMPLE="$SCRIPT_DIR/src/config.example.json"
+
+# Returns 0 if config.json exists and is a valid JSON object
+_config_file_is_valid() {
+  [ -f "$CONFIG_FILE" ] && \
+  [ "$(wc -c < "$CONFIG_FILE")" -gt 10 ] && \
+  jq -e 'type == "object"' "$CONFIG_FILE" > /dev/null 2>&1
+}
+
+# Returns all recursive leaf key-paths present in example but missing from config
+_find_new_keys() {
+  local config_keys example_keys
+  config_keys=$(jq -r '[path(..)] | map(join(".")) | sort[]' "$CONFIG_FILE" 2>/dev/null)
+  example_keys=$(jq -r '[path(..)] | map(join(".")) | sort[]' "$CONFIG_EXAMPLE" 2>/dev/null)
+  comm -13 <(echo "$config_keys") <(echo "$example_keys")
+}
+
+if ! [ -f "$CONFIG_EXAMPLE" ]; then
+  echo "ERROR: config.example.json not found at $CONFIG_EXAMPLE — image may be corrupt." >&2
+  exit 1
+fi
+
+if _config_file_is_valid; then
+  echo "[entrypoint] Using existing config.json."
+  new_keys=$(_find_new_keys)
+  if [ -n "$new_keys" ]; then
+    echo "" >&2
+    echo "┌─────────────────────────────────────────────────────────┐" >&2
+    echo "│  ⚠  CONFIG UPDATE AVAILABLE                             │" >&2
+    echo "│                                                         │" >&2
+    echo "│  Your config.json is missing keys added in a recent     │" >&2
+    echo "│  update. The script will still run, but new features    │" >&2
+    echo "│  may not work correctly.                                │" >&2
+    echo "│                                                         │" >&2
+    echo "│  Missing keys (see config.example.json for defaults):   │" >&2
+    echo "$new_keys" | while IFS= read -r key; do
+      printf "│    %-55s│\n" "+ $key" >&2
+    done
+    echo "│                                                         │" >&2
+    echo "│  To fix: delete ./config/config.json and restart —      │" >&2
+    echo "│  it will be regenerated with all current defaults,      │" >&2
+    echo "│  then re-apply your CONFIG_* env vars.                  │" >&2
+    echo "└─────────────────────────────────────────────────────────┘" >&2
+    echo "" >&2
+  fi
+else
+  echo "[entrypoint] No config.json found — generating from config.example.json."
+  cp "$CONFIG_EXAMPLE" "$CONFIG_FILE"
+  echo "[entrypoint] config.json created. Customise via CONFIG_* env vars in compose.yaml."
+fi
+
+# Apply CONFIG_* env var overrides (always runs, regardless of config source)
+echo "[entrypoint] Applying CONFIG_* environment variable overrides..."
+_cfg() {
+  # _cfg <env_var_value_or_empty> <jq_path> <type: string|bool|number>
+  local val="$1" path="$2" type="${3:-string}"
+  [ -z "$val" ] && return 0
+  case "$type" in
+    bool|number)
+      jq --argjson v "$val" "$path = \$v" "$CONFIG_FILE" > "$CONFIG_FILE.tmp" && mv "$CONFIG_FILE.tmp" "$CONFIG_FILE"
+      ;;
+    *)
+      jq --arg v "$val" "$path = \$v" "$CONFIG_FILE" > "$CONFIG_FILE.tmp" && mv "$CONFIG_FILE.tmp" "$CONFIG_FILE"
+      ;;
+  esac
+  echo "[entrypoint]   $path = $val"
+}
+
+# headless is always forced true — cannot run headed inside Docker
+_cfg 'true'                            '.headless'                                  bool
+
+# Top-level
+_cfg "${CONFIG_CLUSTERS:-}"            '.clusters'                                  number
+_cfg "${CONFIG_DEBUG_LOGS:-}"          '.debugLogs'                                 bool
+_cfg "${CONFIG_ERROR_DIAGNOSTICS:-}"   '.errorDiagnostics'                          bool
+_cfg "${CONFIG_GLOBAL_TIMEOUT:-}"      '.globalTimeout'                             string
+
+# Workers
+_cfg "${CONFIG_WORKER_DAILY_SET:-}"           '.workers.doDailySet'           bool
+_cfg "${CONFIG_WORKER_SPECIAL_PROMOTIONS:-}"  '.workers.doSpecialPromotions'   bool
+_cfg "${CONFIG_WORKER_MORE_PROMOTIONS:-}"     '.workers.doMorePromotions'      bool
+_cfg "${CONFIG_WORKER_PUNCH_CARDS:-}"         '.workers.doPunchCards'          bool
+_cfg "${CONFIG_WORKER_APP_PROMOTIONS:-}"      '.workers.doAppPromotions'       bool
+_cfg "${CONFIG_WORKER_DESKTOP_SEARCH:-}"      '.workers.doDesktopSearch'       bool
+_cfg "${CONFIG_WORKER_MOBILE_SEARCH:-}"       '.workers.doMobileSearch'        bool
+_cfg "${CONFIG_WORKER_DAILY_CHECKIN:-}"       '.workers.doDailyCheckIn'        bool
+_cfg "${CONFIG_WORKER_READ_TO_EARN:-}"        '.workers.doReadToEarn'          bool
+
+# Search settings
+_cfg "${CONFIG_SEARCH_SCROLL_RANDOM:-}"    '.searchSettings.scrollRandomResults'    bool
+_cfg "${CONFIG_SEARCH_CLICK_RANDOM:-}"     '.searchSettings.clickRandomResults'     bool
+_cfg "${CONFIG_SEARCH_PARALLEL:-}"         '.searchSettings.parallelSearching'      bool
+_cfg "${CONFIG_SEARCH_DELAY_MIN:-}"        '.searchSettings.searchDelay.min'        string
+_cfg "${CONFIG_SEARCH_DELAY_MAX:-}"        '.searchSettings.searchDelay.max'        string
+_cfg "${CONFIG_SEARCH_READ_DELAY_MIN:-}"   '.searchSettings.readDelay.min'          string
+_cfg "${CONFIG_SEARCH_READ_DELAY_MAX:-}"   '.searchSettings.readDelay.max'          string
+_cfg "${CONFIG_SEARCH_VISIT_TIME:-}"       '.searchSettings.searchResultVisitTime'  string
+_cfg "${CONFIG_SEARCH_ON_BING_LOCAL:-}"    '.searchOnBingLocalQueries'              bool
+
+# Proxy
+_cfg "${CONFIG_PROXY_QUERY_ENGINE:-}"  '.proxy.queryEngine'  bool
+
+# Console log filter
+# Levels and keywords accept comma-separated values e.g. "error,warn"
+_cfg "${CONFIG_LOG_FILTER_ENABLED:-}"   '.consoleLogFilter.enabled'  bool
+_cfg "${CONFIG_LOG_FILTER_MODE:-}"      '.consoleLogFilter.mode'     string
+_cfg_array() {
+  # _cfg_array <value-or-unset-sentinel> <jq_path>
+  # Uses __UNSET__ sentinel to distinguish "var not set" from "var set to empty".
+  # An empty value writes [] to the config; an unset var is skipped entirely.
+  local val="$1" path="$2"
+  [ "$val" = "__UNSET__" ] && return 0
+  local json_array
+  if [ -z "$val" ]; then
+    json_array="[]"
+  else
+    json_array=$(echo "$val" | jq -Rc '[split(",") | .[] | ltrimstr(" ") | rtrimstr(" ")]')
+  fi
+  jq --argjson v "$json_array" "$path = \$v" "$CONFIG_FILE" > "$CONFIG_FILE.tmp" && mv "$CONFIG_FILE.tmp" "$CONFIG_FILE"
+  echo "[entrypoint]   $path = [$val]"
+}
+_cfg_array "${CONFIG_LOG_FILTER_LEVELS-__UNSET__}"    '.consoleLogFilter.levels'
+_cfg_array "${CONFIG_LOG_FILTER_KEYWORDS-__UNSET__}"  '.consoleLogFilter.keywords'
+
+# Discord webhook
+_cfg "${CONFIG_DISCORD_ENABLED:-}"  '.webhook.discord.enabled'  bool
+_cfg "${CONFIG_DISCORD_URL:-}"      '.webhook.discord.url'      string
+
+# ntfy webhook
+_cfg "${CONFIG_NTFY_ENABLED:-}"   '.webhook.ntfy.enabled'   bool
+_cfg "${CONFIG_NTFY_URL:-}"       '.webhook.ntfy.url'       string
+_cfg "${CONFIG_NTFY_TOPIC:-}"     '.webhook.ntfy.topic'     string
+_cfg "${CONFIG_NTFY_TOKEN:-}"     '.webhook.ntfy.token'     string
+_cfg "${CONFIG_NTFY_TITLE:-}"     '.webhook.ntfy.title'     string
+_cfg "${CONFIG_NTFY_PRIORITY:-}"  '.webhook.ntfy.priority'  number
+_cfg_array "${CONFIG_NTFY_TAGS-__UNSET__}"  '.webhook.ntfy.tags'
+
+# Webhook log filter
+_cfg "${CONFIG_WEBHOOK_LOG_FILTER_ENABLED:-}"  '.webhook.webhookLogFilter.enabled'  bool
+_cfg "${CONFIG_WEBHOOK_LOG_FILTER_MODE:-}"     '.webhook.webhookLogFilter.mode'     string
+_cfg_array "${CONFIG_WEBHOOK_LOG_FILTER_LEVELS-__UNSET__}"    '.webhook.webhookLogFilter.levels'
+_cfg_array "${CONFIG_WEBHOOK_LOG_FILTER_KEYWORDS-__UNSET__}"  '.webhook.webhookLogFilter.keywords'
+
+echo "[entrypoint] Config ready."
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 5. Initial run without sleep if RUN_ON_START=true
+# ─────────────────────────────────────────────────────────────────────────────
 if [ "${RUN_ON_START:-false}" = "true" ]; then
   echo "[entrypoint] Starting initial run in background at $(date)"
   (
-    cd /usr/src/microsoft-rewards-script || {
-      echo "[entrypoint-bg] ERROR: Unable to cd to /usr/src/microsoft-rewards-script" >&2
+    cd "$SCRIPT_DIR" || {
+      echo "[entrypoint-bg] ERROR: Unable to cd to $SCRIPT_DIR" >&2
       exit 1
     }
-    # Skip random sleep for initial run, but preserve setting for cron jobs
     SKIP_RANDOM_SLEEP=true scripts/docker/run_daily.sh
     echo "[entrypoint-bg] Initial run completed at $(date)"
   ) &
   echo "[entrypoint] Background process started (PID: $!)"
 fi
 
-# 4. Template and register cron file with explicit timezone export
+# ─────────────────────────────────────────────────────────────────────────────
+# 6. Template and register cron file
+# ─────────────────────────────────────────────────────────────────────────────
 if [ ! -f /etc/cron.d/microsoft-rewards-cron.template ]; then
   echo "ERROR: Cron template /etc/cron.d/microsoft-rewards-cron.template not found." >&2
   exit 1
 fi
 
-# Export TZ for envsubst to use
 export TZ
 envsubst < /etc/cron.d/microsoft-rewards-cron.template > /etc/cron.d/microsoft-rewards-cron
 chmod 0644 /etc/cron.d/microsoft-rewards-cron
@@ -46,5 +358,7 @@ crontab /etc/cron.d/microsoft-rewards-cron
 
 echo "[entrypoint] Cron configured with schedule: $CRON_SCHEDULE and timezone: $TZ; starting cron at $(date)"
 
-# 5. Start cron in foreground (PID 1)
+# ─────────────────────────────────────────────────────────────────────────────
+# 7. Start cron in foreground (PID 1)
+# ─────────────────────────────────────────────────────────────────────────────
 exec cron -f

--- a/scripts/docker/entrypoint.sh
+++ b/scripts/docker/entrypoint.sh
@@ -191,11 +191,12 @@ _config_file_is_valid() {
   jq -e 'type == "object"' "$CONFIG_FILE" > /dev/null 2>&1
 }
 
-# Returns all recursive leaf key-paths present in example but missing from config
+# Returns object key-paths present in example but missing from config.
 _find_new_keys() {
   local config_keys example_keys
-  config_keys=$(jq -r '[path(..)] | map(join(".")) | sort[]' "$CONFIG_FILE" 2>/dev/null)
-  example_keys=$(jq -r '[path(..)] | map(join(".")) | sort[]' "$CONFIG_EXAMPLE" 2>/dev/null)
+  local jq_expr='[path(..)] | map(select(all(. ; type == "string")) | join(".")) | sort[]'
+  config_keys=$(jq -r "$jq_expr" "$CONFIG_FILE" 2>/dev/null)
+  example_keys=$(jq -r "$jq_expr" "$CONFIG_EXAMPLE" 2>/dev/null)
   comm -13 <(echo "$config_keys") <(echo "$example_keys")
 }
 


### PR DESCRIPTION
# Summary
## Automatic creation of accounts.json and config.json for Docker users

- A valid `accounts.json` and `config.json` are auto-generated on first run and saved locally into ./config/
- Account credentials are set in a .env (recommended) or directly in compose.yaml
- Added env.example as a credentials template
- All user config options are set via environment `CONFIG_*` vars in the compose.yaml. Common options are included in the sample `compose.yaml` (e.g., clusters, webhook), with a full reference added to config options table in the README

## Updated config handling

- Users are warned in logs if a new image adds config keys missing from their existing config.json (e.g., new features added and example config changed)
- To update, the user can delete the generated`./config/config.json` and restart, a fresh one will be generated from the latest `config.example.json` with all `CONFIG_*` overrides re-applied automatically

## Files changed
- Dockerfile: added a `jq` and `envsubst` dependencies to the run stage to handle the accounts and config
- scripts/docker/entrypoint.sh: added logic for account and config generation, added log outputs for user to see what was customized in the config on first run, added warn outputs if new example detected
- compose.yaml: added support and comments for config and accounts
- env.example (new): sample accounts file
- README.md: updated docker instructions, added config env vars to config table.