### PR TITLE
Save accounts stats in sqlite file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,10 @@ node_modules/
 src/accounts.json
 src/config.json
 /.vscode
+/.idea
 /diagnostics
 note
+accounts.db
 accounts.dev.json
 accounts.main.json
 .DS_Store

--- a/scripts/docker/entrypoint.sh
+++ b/scripts/docker/entrypoint.sh
@@ -326,6 +326,10 @@ _cfg "${CONFIG_WEBHOOK_LOG_FILTER_MODE:-}"     '.webhook.webhookLogFilter.mode' 
 _cfg_array "${CONFIG_WEBHOOK_LOG_FILTER_LEVELS-__UNSET__}"    '.webhook.webhookLogFilter.levels'
 _cfg_array "${CONFIG_WEBHOOK_LOG_FILTER_KEYWORDS-__UNSET__}"  '.webhook.webhookLogFilter.keywords'
 
+# Save accounts results
+_cfg "${CONFIG_SAVERESULTS_ENABLED:-}"  '.saveResults.enabled'  bool
+_cfg "${CONFIG_SAVERESULTS_DBPATH:-}"  '.saveResults.dbPath'  string
+
 echo "[entrypoint] Config ready."
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/src/config.example.json
+++ b/src/config.example.json
@@ -21,7 +21,12 @@
         "scrollRandomResults": false,
         "clickRandomResults": false,
         "parallelSearching": true,
-        "queryEngines": ["google", "wikipedia", "reddit", "local"],
+        "queryEngines": [
+            "google",
+            "wikipedia",
+            "reddit",
+            "local"
+        ],
         "searchResultVisitTime": "10sec",
         "searchDelay": {
             "min": "30sec",
@@ -36,8 +41,13 @@
     "consoleLogFilter": {
         "enabled": false,
         "mode": "whitelist",
-        "levels": ["error", "warn"],
-        "keywords": ["starting account"],
+        "levels": [
+            "error",
+            "warn"
+        ],
+        "keywords": [
+            "starting account"
+        ],
         "regexPatterns": []
     },
     "proxy": {
@@ -54,15 +64,28 @@
             "topic": "",
             "token": "",
             "title": "Microsoft-Rewards-Script",
-            "tags": ["bot", "notify"],
+            "tags": [
+                "bot",
+                "notify"
+            ],
             "priority": 3
         },
         "webhookLogFilter": {
             "enabled": false,
             "mode": "whitelist",
-            "levels": ["error"],
-            "keywords": ["starting account", "select number", "collected"],
+            "levels": [
+                "error"
+            ],
+            "keywords": [
+                "starting account",
+                "select number",
+                "collected"
+            ],
             "regexPatterns": []
         }
+    },
+    "saveResults": {
+        "enabled": false,
+        "dbPath": "accounts.db"
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import { sendDiscord, flushDiscordQueue } from './logging/Discord'
 import { sendNtfy, flushNtfyQueue } from './logging/Ntfy'
 import type { DashboardData } from './interface/DashboardData'
 import type { AppDashboardData } from './interface/AppDashBoardData'
+import { Database } from './logging/Database'
 
 interface ExecutionContext {
     isMobile: boolean
@@ -36,7 +37,7 @@ interface BrowserSession {
     fingerprint: BrowserFingerprintWithHeaders
 }
 
-interface AccountStats {
+export interface AccountStats {
     email: string
     initialPoints: number
     finalPoints: number
@@ -97,6 +98,7 @@ export class MicrosoftRewardsBot {
     private searchManager: SearchManager
 
     public axios!: AxiosClient
+    public db!: Database
 
     constructor() {
         this.userData = {
@@ -128,6 +130,7 @@ export class MicrosoftRewardsBot {
 
     async initialize(): Promise<void> {
         this.accounts = loadAccounts()
+        this.db = new Database(this.config.saveResults)
     }
 
     async run(): Promise<void> {
@@ -310,14 +313,16 @@ export class MicrosoftRewardsBot {
                     const accountInitialPoints = result.initialPoints ?? 0
                     const accountFinalPoints = accountInitialPoints + collectedPoints
 
-                    accountStats.push({
+                    const successStats: AccountStats = {
                         email: accountEmail,
                         initialPoints: accountInitialPoints,
                         finalPoints: accountFinalPoints,
                         collectedPoints: collectedPoints,
                         duration: parseFloat(durationSeconds),
                         success: true
-                    })
+                    }
+                    accountStats.push(successStats)
+                    this.db.saveAccountResult(successStats)
 
                     this.logger.info(
                         'main',
@@ -326,7 +331,7 @@ export class MicrosoftRewardsBot {
                         'green'
                     )
                 } else {
-                    accountStats.push({
+                    const failStats: AccountStats = {
                         email: accountEmail,
                         initialPoints: 0,
                         finalPoints: 0,
@@ -334,7 +339,9 @@ export class MicrosoftRewardsBot {
                         duration: parseFloat(durationSeconds),
                         success: false,
                         error: 'Flow failed'
-                    })
+                    }
+                    accountStats.push(failStats)
+                    this.db.saveAccountResult(failStats)
                 }
             } catch (error) {
                 const durationSeconds = ((Date.now() - accountStartTime) / 1000).toFixed(1)
@@ -344,7 +351,7 @@ export class MicrosoftRewardsBot {
                     `${accountEmail}: ${error instanceof Error ? error.message : String(error)}`
                 )
 
-                accountStats.push({
+                const errorStats: AccountStats = {
                     email: accountEmail,
                     initialPoints: 0,
                     finalPoints: 0,
@@ -352,7 +359,9 @@ export class MicrosoftRewardsBot {
                     duration: parseFloat(durationSeconds),
                     success: false,
                     error: error instanceof Error ? error.message : String(error)
-                })
+                }
+                accountStats.push(errorStats)
+                this.db.saveAccountResult(errorStats)
             }
         }
 
@@ -432,8 +441,7 @@ export class MicrosoftRewardsBot {
                 this.logger.info(
                     'main',
                     'POINTS',
-                    `Earnable today | Mobile: ${this.pointsCanCollect} | Browser: ${
-                        browserEarnable.mobileSearchPoints
+                    `Earnable today | Mobile: ${this.pointsCanCollect} | Browser: ${browserEarnable.mobileSearchPoints
                     } | App: ${appEarnable?.totalEarnablePoints ?? 0} | ${accountEmail} | locale: ${this.userData.geoLocale}`
                 )
 
@@ -482,7 +490,7 @@ export class MicrosoftRewardsBot {
                     await executionContext.run({ isMobile: true, account }, async () => {
                         await this.browser.func.closeBrowser(mobileSession!.context, accountEmail)
                     })
-                } catch {}
+                } catch { }
             }
         }
     }

--- a/src/interface/Config.ts
+++ b/src/interface/Config.ts
@@ -12,6 +12,12 @@ export interface Config {
     proxy: ConfigProxy
     consoleLogFilter: LogFilter
     webhook: ConfigWebhook
+    saveResults?: ConfigSaveResults
+}
+
+export interface ConfigSaveResults {
+    enabled: boolean
+    dbPath?: string
 }
 
 export type QueryEngine = 'google' | 'wikipedia' | 'reddit' | 'local'

--- a/src/logging/Database.ts
+++ b/src/logging/Database.ts
@@ -1,0 +1,59 @@
+import { DatabaseSync } from 'node:sqlite'
+import path from 'path'
+
+import type { AccountStats } from '../index'
+import type { ConfigSaveResults } from '../interface/Config'
+
+export class Database {
+    private db: DatabaseSync | null = null
+
+    constructor(config?: ConfigSaveResults) {
+        if (!config?.enabled) {
+            return
+        }
+
+        const dbPath = config.dbPath || 'accounts.db'
+        const fullPath = path.resolve(process.cwd(), dbPath)
+
+        this.db = new DatabaseSync(fullPath)
+        this.initDatabase()
+    }
+
+    private initDatabase() {
+        this.db!.exec(`
+            CREATE TABLE IF NOT EXISTS account_results (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                email TEXT NOT NULL,
+                initialPoints INTEGER NOT NULL,
+                finalPoints INTEGER NOT NULL,
+                collectedPoints INTEGER NOT NULL,
+                duration REAL NOT NULL,
+                success INTEGER NOT NULL,
+                error TEXT,
+                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+            )
+        `)
+    }
+
+    public saveAccountResult(stats: AccountStats) {
+        if (!this.db) {
+            return
+        }
+
+        const stmt = this.db.prepare(`
+            INSERT INTO account_results (
+                email, initialPoints, finalPoints, collectedPoints, duration, success, error
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        `)
+
+        stmt.run(
+            stats.email,
+            stats.initialPoints,
+            stats.finalPoints,
+            stats.collectedPoints,
+            stats.duration,
+            stats.success ? 1 : 0,
+            stats.error || null
+        )
+    }
+}

--- a/src/util/Validator.ts
+++ b/src/util/Validator.ts
@@ -78,7 +78,13 @@ export const ConfigSchema = z.object({
         queryEngine: z.boolean()
     }),
     consoleLogFilter: LogFilterSchema,
-    webhook: WebhookSchema
+    webhook: WebhookSchema,
+    saveResults: z
+        .object({
+            enabled: z.boolean(),
+            dbPath: z.string().optional()
+        })
+        .optional()
 })
 
 // Account


### PR DESCRIPTION
## Summary
This PR introduces optional **SQLite integration** to store accounts statistics for the Microsoft Rewards script.

The goal is to persist useful data about each account across runs, allowing better tracking of script activity and rewards progress.

## Why
Previously, the script did not persist execution data between runs.  
With SQLite integration, it is now possible to keep track of statistics for each account, making it easier to monitor usage and analyze results over time.

## Impact
- Adds persistent statistics tracking
- No external database server required
- It's optional and is disabled by default

## Testing
- Verified database creation on first run
- Confirmed that account statistics are correctly inserted and updated
- Tested multiple runs to ensure data persists across executions

## Notes
The database file is created automatically if it does not exist. No additional setup is required from the user.