### PR TITLE
feat(auth): add manual password input when password not configured

### DIFF
--- a/src/browser/auth/methods/EmailLogin.ts
+++ b/src/browser/auth/methods/EmailLogin.ts
@@ -1,8 +1,10 @@
 import type { Page } from 'patchright'
 import type { MicrosoftRewardsBot } from '../../../index'
+import { getErrorMessage, promptInput } from './LoginUtils'
 
 export class EmailLogin {
     private submitButton = 'button[type="submit"]'
+    private readonly maxManualSeconds = 120
 
     constructor(private bot: MicrosoftRewardsBot) {}
 
@@ -58,6 +60,21 @@ export class EmailLogin {
                 return 'error'
             }
 
+            // 密码为空时，提示手动输入
+            password = password?.trim() ? password : ''
+            if (!password) {
+                this.bot.logger.info(this.bot.isMobile, 'LOGIN-ENTER-PASSWORD', 'No password provided, awaiting manual input')
+                password = await promptInput({
+                    question: `Enter your password (waiting ${this.maxManualSeconds}s): `,
+                    timeoutSeconds: this.maxManualSeconds,
+                    transform: input => input.trim()
+                }) ?? ''
+                if (!password) {
+                    this.bot.logger.error(this.bot.isMobile, 'LOGIN-ENTER-PASSWORD', 'Password input timed out')
+                    return 'error'
+                }
+            }
+
             await this.bot.utils.wait(1000)
             await page.fill(passwordInputSelector, '').catch(() => {})
             await this.bot.utils.wait(500)
@@ -71,6 +88,13 @@ export class EmailLogin {
             if (submitButton) {
                 await this.bot.browser.utils.ghostClick(page, this.submitButton)
                 this.bot.logger.info(this.bot.isMobile, 'LOGIN-ENTER-PASSWORD', 'Password submitted')
+            }
+
+            await page.waitForLoadState('networkidle', { timeout: 5000 }).catch(() => {})
+            const errorMessage = await getErrorMessage(page)
+            if (errorMessage) {
+                this.bot.logger.warn(this.bot.isMobile, 'LOGIN-ENTER-PASSWORD', `Password error: ${errorMessage}`)
+                return 'error'
             }
 
             return 'ok'


### PR DESCRIPTION
## Summary

- When password is empty or whitespace-only in config, prompt user to input password manually via terminal
- 120 seconds timeout for manual input
- Adds error message checking after password submission
- Follows the same pattern as existing TOTP manual input flow

## Changes

- `src/browser/auth/methods/EmailLogin.ts`: Add manual password input support with `promptInput` utility

## Test plan

1. Configure an account without password
2. Run login flow, observe log: `No password provided, awaiting manual input`
3. Enter password in terminal, verify successful login
4. Test timeout scenario (no input for 120s)