### PR TITLE
  Fix: Bing session verification fails for non-US regions + network fallback

### DIFF
--- a/src/browser/BrowserUtils.ts
+++ b/src/browser/BrowserUtils.ts
@@ -11,9 +11,6 @@ export default class BrowserUtils {
         this.bot = bot
     }
 
-    /**
-     * 检查页面是否仍然可用（未崩溃）
-     */
     private isPageHealthy(page: Page): boolean {
         try {
             return !page.isClosed()
@@ -22,9 +19,6 @@ export default class BrowserUtils {
         }
     }
 
-    /**
-     * 检查错误是否为浏览器崩溃错误
-     */
     private isBrowserCrashError(error: unknown): boolean {
         const message = error instanceof Error ? error.message : String(error)
         return message.includes('Target crashed') ||
@@ -35,7 +29,6 @@ export default class BrowserUtils {
 
     async tryDismissAllMessages(page: Page): Promise<boolean> {
         try {
-            // 初始健康检查
             if (!this.isPageHealthy(page)) {
                 this.bot.logger.warn(this.bot.isMobile, 'DISMISS-ALL-MESSAGES', 'Page is closed or crashed, skipping')
                 return false
@@ -56,7 +49,6 @@ export default class BrowserUtils {
                 { selector: '#reward_pivot_earn', label: 'Reward Coupon Accept' }
             ]
 
-            // 移除不稳定的通配符选择器，改用更稳定的选择器
             const cookieBannerSelectors = [
                 '#wcpConsentBannerCtrl button:first-child',
                 '#wcpConsentBannerCtrl .action-button',
@@ -79,10 +71,9 @@ export default class BrowserUtils {
                 .map(r => (r.status === 'fulfilled' ? r.value : null))
                 .filter(Boolean)
 
-            // 串行处理点击，避免并发导致的崩溃
+            // Process clicks serially to avoid crashes
             let dismissedCount = 0
             for (const b of visibleButtons) {
-                // 每次点击前检查页面健康状态
                 if (!this.isPageHealthy(page)) {
                     this.bot.logger.warn(this.bot.isMobile, 'DISMISS-ALL-MESSAGES', 'Page became unhealthy during dismissal')
                     return dismissedCount > 0
@@ -98,7 +89,6 @@ export default class BrowserUtils {
                         )
                         dismissedCount++
                     }
-                    // 每次点击后短暂等待，让页面稳定
                     await this.bot.utils.wait(200)
                 }
             }
@@ -107,7 +97,7 @@ export default class BrowserUtils {
                 await this.bot.utils.wait(300)
             }
 
-            // 处理 Cookie 横幅（特殊处理，更安全的方式）
+            // Handle cookie banner
             if (this.isPageHealthy(page)) {
                 for (const selector of cookieBannerSelectors) {
                     if (!this.isPageHealthy(page)) break
@@ -127,12 +117,12 @@ export default class BrowserUtils {
                             }
                         }
                     } catch {
-                        // 继续尝试下一个选择器
+                        // Try next selector
                     }
                 }
             }
 
-            // Overlay 处理
+            // Handle overlay
             if (this.isPageHealthy(page)) {
                 const overlay = await page.$('#bnp_overlay_wrapper').catch(() => null)
                 if (overlay) {
@@ -155,14 +145,13 @@ export default class BrowserUtils {
 
             return true
         } catch (error) {
-            // 检测是否为浏览器崩溃
             if (this.isBrowserCrashError(error)) {
                 this.bot.logger.error(
                     this.bot.isMobile,
                     'DISMISS-ALL-MESSAGES',
                     'Browser crashed during message dismissal'
                 )
-                throw error // 重新抛出崩溃错误，让上层处理
+                throw error
             }
 
             this.bot.logger.warn(
@@ -232,13 +221,11 @@ export default class BrowserUtils {
                 `Found ${tabs.length} tab(s) open (min: ${config.minTabs}, max: ${config.maxTabs})`
             )
 
-            // Check if valid
             if (config.minTabs < 1 || config.maxTabs < config.minTabs) {
                 this.bot.logger.warn(this.bot.isMobile, 'SEARCH-CLOSE-TABS', 'Invalid config, using defaults')
                 config = { minTabs: 1, maxTabs: 1 }
             }
 
-            // Close if more than max config
             if (tabs.length > config.maxTabs) {
                 const tabsToClose = tabs.slice(config.maxTabs)
 
@@ -251,7 +238,6 @@ export default class BrowserUtils {
                     `Closed ${closedCount}/${tabsToClose.length} excess tab(s) to reach max of ${config.maxTabs}`
                 )
 
-                // Open more tabs
             } else if (tabs.length < config.minTabs) {
                 const tabsNeeded = config.minTabs - tabs.length
                 this.bot.logger.debug(
@@ -298,7 +284,6 @@ export default class BrowserUtils {
 
     async ghostClick(page: Page, selector: string, options?: ClickOptions): Promise<boolean> {
         try {
-            // 页面健康检查
             if (!this.isPageHealthy(page)) {
                 this.bot.logger.warn(this.bot.isMobile, 'GHOST-CLICK', 'Page is closed or crashed, cannot click')
                 return false
@@ -310,10 +295,8 @@ export default class BrowserUtils {
                 `Trying to click selector: ${selector}, options: ${JSON.stringify(options)}`
             )
 
-            // Wait for selector to exist before clicking
             await page.waitForSelector(selector, { timeout: 1000 }).catch(() => {})
 
-            // 再次检查页面状态
             if (!this.isPageHealthy(page)) {
                 this.bot.logger.warn(this.bot.isMobile, 'GHOST-CLICK', 'Page became unhealthy during wait')
                 return false
@@ -324,14 +307,13 @@ export default class BrowserUtils {
 
             return true
         } catch (error) {
-            // 检测浏览器崩溃
             if (this.isBrowserCrashError(error)) {
                 this.bot.logger.error(
                     this.bot.isMobile,
                     'GHOST-CLICK',
                     `Browser crashed while clicking ${selector}`
                 )
-                throw error // 重新抛出崩溃错误
+                throw error
             }
 
             this.bot.logger.warn(

--- a/src/browser/BrowserUtils.ts
+++ b/src/browser/BrowserUtils.ts
@@ -11,11 +11,39 @@ export default class BrowserUtils {
         this.bot = bot
     }
 
-    async tryDismissAllMessages(page: Page): Promise<void> {
+    /**
+     * 检查页面是否仍然可用（未崩溃）
+     */
+    private isPageHealthy(page: Page): boolean {
         try {
+            return !page.isClosed()
+        } catch {
+            return false
+        }
+    }
+
+    /**
+     * 检查错误是否为浏览器崩溃错误
+     */
+    private isBrowserCrashError(error: unknown): boolean {
+        const message = error instanceof Error ? error.message : String(error)
+        return message.includes('Target crashed') ||
+               message.includes('Session closed') ||
+               message.includes('Page crashed') ||
+               message.includes('Target closed')
+    }
+
+    async tryDismissAllMessages(page: Page): Promise<boolean> {
+        try {
+            // 初始健康检查
+            if (!this.isPageHealthy(page)) {
+                this.bot.logger.warn(this.bot.isMobile, 'DISMISS-ALL-MESSAGES', 'Page is closed or crashed, skipping')
+                return false
+            }
+
             const buttons = [
                 { selector: '#acceptButton', label: 'AcceptButton' },
-                { selector: '#wcpConsentBannerCtrl > * > button:first-child', label: 'Bing Cookies Accept' },
+                { selector: '#bnp_btn_accept', label: 'Bing Cookie Banner' },
                 { selector: '.ext-secondary.ext-button', label: '"Skip for now" Button' },
                 { selector: '#iLandingViewAction', label: 'iLandingViewAction' },
                 { selector: '#iShowSkip', label: 'iShowSkip' },
@@ -25,8 +53,15 @@ export default class BrowserUtils {
                 { selector: '.ms-Button.ms-Button--primary', label: 'Primary Button' },
                 { selector: '.c-glyph.glyph-cancel', label: 'Mobile Welcome Button' },
                 { selector: '.maybe-later', label: 'Mobile Rewards App Banner' },
-                { selector: '#bnp_btn_accept', label: 'Bing Cookie Banner' },
                 { selector: '#reward_pivot_earn', label: 'Reward Coupon Accept' }
+            ]
+
+            // 移除不稳定的通配符选择器，改用更稳定的选择器
+            const cookieBannerSelectors = [
+                '#wcpConsentBannerCtrl button:first-child',
+                '#wcpConsentBannerCtrl .action-button',
+                'button[data-bind*="acceptAll"]',
+                'button[aria-label*="Accept" i]'
             ]
 
             const checkVisible = await Promise.allSettled(
@@ -44,48 +79,98 @@ export default class BrowserUtils {
                 .map(r => (r.status === 'fulfilled' ? r.value : null))
                 .filter(Boolean)
 
-            if (visibleButtons.length > 0) {
-                await Promise.allSettled(
-                    visibleButtons.map(async b => {
-                        if (b) {
-                            const clicked = await this.ghostClick(page, b.selector)
+            // 串行处理点击，避免并发导致的崩溃
+            let dismissedCount = 0
+            for (const b of visibleButtons) {
+                // 每次点击前检查页面健康状态
+                if (!this.isPageHealthy(page)) {
+                    this.bot.logger.warn(this.bot.isMobile, 'DISMISS-ALL-MESSAGES', 'Page became unhealthy during dismissal')
+                    return dismissedCount > 0
+                }
+
+                if (b) {
+                    const clicked = await this.ghostClick(page, b.selector)
+                    if (clicked) {
+                        this.bot.logger.debug(
+                            this.bot.isMobile,
+                            'DISMISS-ALL-MESSAGES',
+                            `Dismissed: ${b.label}`
+                        )
+                        dismissedCount++
+                    }
+                    // 每次点击后短暂等待，让页面稳定
+                    await this.bot.utils.wait(200)
+                }
+            }
+
+            if (dismissedCount > 0) {
+                await this.bot.utils.wait(300)
+            }
+
+            // 处理 Cookie 横幅（特殊处理，更安全的方式）
+            if (this.isPageHealthy(page)) {
+                for (const selector of cookieBannerSelectors) {
+                    if (!this.isPageHealthy(page)) break
+
+                    try {
+                        const isVisible = await page.locator(selector).isVisible().catch(() => false)
+                        if (isVisible) {
+                            const clicked = await this.ghostClick(page, selector)
                             if (clicked) {
                                 this.bot.logger.debug(
                                     this.bot.isMobile,
                                     'DISMISS-ALL-MESSAGES',
-                                    `Dismissed: ${b.label}`
+                                    `Dismissed: Cookie Banner (${selector})`
                                 )
+                                await this.bot.utils.wait(500)
+                                break
                             }
                         }
-                    })
-                )
-                await this.bot.utils.wait(300)
-            }
-
-            // Overlay
-            const overlay = await page.$('#bnp_overlay_wrapper')
-            if (overlay) {
-                const rejected = await this.ghostClick(page, '#bnp_btn_reject, button[aria-label*="Reject" i]')
-                if (rejected) {
-                    this.bot.logger.debug(this.bot.isMobile, 'DISMISS-ALL-MESSAGES', 'Dismissed: Bing Overlay Reject')
-                } else {
-                    const accepted = await this.ghostClick(page, '#bnp_btn_accept')
-                    if (accepted) {
-                        this.bot.logger.debug(
-                            this.bot.isMobile,
-                            'DISMISS-ALL-MESSAGES',
-                            'Dismissed: Bing Overlay Accept'
-                        )
+                    } catch {
+                        // 继续尝试下一个选择器
                     }
                 }
-                await this.bot.utils.wait(250)
             }
+
+            // Overlay 处理
+            if (this.isPageHealthy(page)) {
+                const overlay = await page.$('#bnp_overlay_wrapper').catch(() => null)
+                if (overlay) {
+                    const rejected = await this.ghostClick(page, '#bnp_btn_reject, button[aria-label*="Reject" i]')
+                    if (rejected) {
+                        this.bot.logger.debug(this.bot.isMobile, 'DISMISS-ALL-MESSAGES', 'Dismissed: Bing Overlay Reject')
+                    } else {
+                        const accepted = await this.ghostClick(page, '#bnp_btn_accept')
+                        if (accepted) {
+                            this.bot.logger.debug(
+                                this.bot.isMobile,
+                                'DISMISS-ALL-MESSAGES',
+                                'Dismissed: Bing Overlay Accept'
+                            )
+                        }
+                    }
+                    await this.bot.utils.wait(250)
+                }
+            }
+
+            return true
         } catch (error) {
+            // 检测是否为浏览器崩溃
+            if (this.isBrowserCrashError(error)) {
+                this.bot.logger.error(
+                    this.bot.isMobile,
+                    'DISMISS-ALL-MESSAGES',
+                    'Browser crashed during message dismissal'
+                )
+                throw error // 重新抛出崩溃错误，让上层处理
+            }
+
             this.bot.logger.warn(
                 this.bot.isMobile,
                 'DISMISS-ALL-MESSAGES',
                 `Handler error: ${error instanceof Error ? error.message : String(error)}`
             )
+            return false
         }
     }
 
@@ -213,6 +298,12 @@ export default class BrowserUtils {
 
     async ghostClick(page: Page, selector: string, options?: ClickOptions): Promise<boolean> {
         try {
+            // 页面健康检查
+            if (!this.isPageHealthy(page)) {
+                this.bot.logger.warn(this.bot.isMobile, 'GHOST-CLICK', 'Page is closed or crashed, cannot click')
+                return false
+            }
+
             this.bot.logger.debug(
                 this.bot.isMobile,
                 'GHOST-CLICK',
@@ -222,11 +313,27 @@ export default class BrowserUtils {
             // Wait for selector to exist before clicking
             await page.waitForSelector(selector, { timeout: 1000 }).catch(() => {})
 
+            // 再次检查页面状态
+            if (!this.isPageHealthy(page)) {
+                this.bot.logger.warn(this.bot.isMobile, 'GHOST-CLICK', 'Page became unhealthy during wait')
+                return false
+            }
+
             const cursor = createCursor(page as any)
             await cursor.click(selector, options)
 
             return true
         } catch (error) {
+            // 检测浏览器崩溃
+            if (this.isBrowserCrashError(error)) {
+                this.bot.logger.error(
+                    this.bot.isMobile,
+                    'GHOST-CLICK',
+                    `Browser crashed while clicking ${selector}`
+                )
+                throw error // 重新抛出崩溃错误
+            }
+
             this.bot.logger.warn(
                 this.bot.isMobile,
                 'GHOST-CLICK',

--- a/src/browser/auth/Login.ts
+++ b/src/browser/auth/Login.ts
@@ -605,7 +605,9 @@ export class Login {
                 }
 
                 const u = new URL(page.url())
-                const atBingHome = u.hostname === 'www.bing.com' && u.pathname === '/'
+                // 支持所有 Bing 域名（包括 cn.bing.com 等区域域名）
+                const isBingDomain = u.hostname.endsWith('.bing.com') || u.hostname === 'bing.com'
+                const atBingHome = isBingDomain && u.pathname === '/'
                 this.bot.logger.debug(
                     this.bot.isMobile,
                     'LOGIN-BING',
@@ -639,6 +641,17 @@ export class Login {
                 `Verification error: ${error instanceof Error ? error.message : String(error)}`
             )
         }
+    }
+
+    /**
+     * 检查错误是否为浏览器崩溃错误
+     */
+    private isBrowserCrashError(error: unknown): boolean {
+        const message = error instanceof Error ? error.message : String(error)
+        return message.includes('Target crashed') ||
+               message.includes('Session closed') ||
+               message.includes('Page crashed') ||
+               message.includes('Target closed')
     }
 
     private async getRewardsSession(page: Page) {
@@ -717,6 +730,14 @@ export class Login {
                 'No RequestVerificationToken found, some activities may not work'
             )
         } catch (error) {
+            // 检测浏览器崩溃
+            if (this.isBrowserCrashError(error)) {
+                throw this.bot.logger.error(
+                    this.bot.isMobile,
+                    'GET-REWARD-SESSION',
+                    'Browser crashed during session retrieval'
+                )
+            }
             throw this.bot.logger.error(
                 this.bot.isMobile,
                 'GET-REWARD-SESSION',

--- a/src/browser/auth/Login.ts
+++ b/src/browser/auth/Login.ts
@@ -605,7 +605,7 @@ export class Login {
                 }
 
                 const u = new URL(page.url())
-                // 支持所有 Bing 域名（包括 cn.bing.com 等区域域名）
+                // Support all Bing domains (including cn.bing.com, etc.)
                 const isBingDomain = u.hostname.endsWith('.bing.com') || u.hostname === 'bing.com'
                 const atBingHome = isBingDomain && u.pathname === '/'
                 this.bot.logger.debug(
@@ -643,9 +643,6 @@ export class Login {
         }
     }
 
-    /**
-     * 检查错误是否为浏览器崩溃错误
-     */
     private isBrowserCrashError(error: unknown): boolean {
         const message = error instanceof Error ? error.message : String(error)
         return message.includes('Target crashed') ||
@@ -730,7 +727,7 @@ export class Login {
                 'No RequestVerificationToken found, some activities may not work'
             )
         } catch (error) {
-            // 检测浏览器崩溃
+            // Check for browser crash
             if (this.isBrowserCrashError(error)) {
                 throw this.bot.logger.error(
                     this.bot.isMobile,

--- a/src/functions/QueryEngine.ts
+++ b/src/functions/QueryEngine.ts
@@ -35,7 +35,7 @@ export class QueryCore {
                 `start | shuffle=${shuffle}, related=${related}, lang=${langCode}, geo=${geoLocale}, sources=${sourceOrder.join(',')}`
             )
 
-            // 网络检测：如果网络不可达，回落到 local 查询
+            // Network check: fall back to local queries if unreachable
             let effectiveSourceOrder = sourceOrder
             if (!skipNetworkCheck) {
                 try {
@@ -51,7 +51,7 @@ export class QueryCore {
                     }
                     effectiveSourceOrder = effectiveOrder as QueryEngine[]
                 } catch {
-                    // 网络检测失败，继续使用原有配置
+                    // Network check failed, use default source order
                     this.bot.logger.debug(this.bot.isMobile, 'QUERY-MANAGER', 'Network check failed, using default source order')
                 }
             }

--- a/src/functions/QueryEngine.ts
+++ b/src/functions/QueryEngine.ts
@@ -4,6 +4,7 @@ import path from 'path'
 import type { GoogleSearch, GoogleTrendsResponse, RedditListing, WikipediaTopResponse } from '../interface/Search'
 import type { MicrosoftRewardsBot } from '../index'
 import { QueryEngine } from '../interface/Config'
+import { NetworkDetector } from '../util/NetworkDetector'
 
 export class QueryCore {
     constructor(private bot: MicrosoftRewardsBot) {}
@@ -15,6 +16,7 @@ export class QueryCore {
             related?: boolean
             langCode?: string
             geoLocale?: string
+            skipNetworkCheck?: boolean
         } = {}
     ): Promise<string[]> {
         const {
@@ -22,7 +24,8 @@ export class QueryCore {
             sourceOrder = ['google', 'wikipedia', 'reddit', 'local'],
             related = true,
             langCode = 'en',
-            geoLocale = 'US'
+            geoLocale = 'US',
+            skipNetworkCheck = false
         } = options
 
         try {
@@ -31,6 +34,27 @@ export class QueryCore {
                 'QUERY-MANAGER',
                 `start | shuffle=${shuffle}, related=${related}, lang=${langCode}, geo=${geoLocale}, sources=${sourceOrder.join(',')}`
             )
+
+            // 网络检测：如果网络不可达，回落到 local 查询
+            let effectiveSourceOrder = sourceOrder
+            if (!skipNetworkCheck) {
+                try {
+                    const effectiveOrder = await NetworkDetector.getSourceOrderWithFallback(sourceOrder, {
+                        timeout: 1000
+                    })
+                    if (effectiveOrder[0] === 'local' && sourceOrder[0] !== 'local') {
+                        this.bot.logger.warn(
+                            this.bot.isMobile,
+                            'QUERY-MANAGER',
+                            'Network unreachable, falling back to local queries only'
+                        )
+                    }
+                    effectiveSourceOrder = effectiveOrder as QueryEngine[]
+                } catch {
+                    // 网络检测失败，继续使用原有配置
+                    this.bot.logger.debug(this.bot.isMobile, 'QUERY-MANAGER', 'Network check failed, using default source order')
+                }
+            }
 
             const topicLists: string[][] = []
 
@@ -60,7 +84,7 @@ export class QueryCore {
                 }
             }
 
-            for (const source of sourceOrder) {
+            for (const source of effectiveSourceOrder) {
                 const handler = sourceHandlers[source]
                 if (!handler) continue
 

--- a/src/util/NetworkDetector.ts
+++ b/src/util/NetworkDetector.ts
@@ -3,9 +3,6 @@ import { promisify } from 'util'
 
 const execAsync = promisify(exec)
 
-/**
- * 网络检测结果接口
- */
 export interface NetworkCheckResult {
     reachable: boolean
     checkedUrls: string[]
@@ -13,48 +10,28 @@ export interface NetworkCheckResult {
     checkTime: number
 }
 
-/**
- * 网络检测配置接口
- */
 export interface NetworkCheckOptions {
-    /** 超时时间（毫秒），默认 1000ms */
+    /** Timeout in milliseconds, default 1000ms */
     timeout?: number
-    /** 要检测的 URL 列表，默认使用查询引擎相关的 URL */
+    /** URLs to check, defaults to query engine URLs */
     urls?: string[]
-    /** 是否使用代理，默认 false */
+    /** Whether to use proxy, default false */
     useProxy?: boolean
 }
 
-/**
- * 网络检测器类
- * 用于检测网络是否可达，支持自动回落到本地查询
- */
 export class NetworkDetector {
-    /** 默认检测的 URL 列表（来自各查询引擎） */
     private static readonly DEFAULT_CHECK_URLS = [
-        'https://trends.google.com', // Google Trends
-        'https://wikimedia.org', // Wikipedia
-        'https://www.reddit.com', // Reddit
-        'https://www.bing.com' // Bing（辅助 API）
+        'https://trends.google.com',
+        'https://wikimedia.org',
+        'https://www.reddit.com',
+        'https://www.bing.com'
     ]
 
-    /**
-     * 使用 curl 检测单个 URL 是否可达
-     * @param url 要检测的 URL
-     * @param timeout 超时时间（毫秒）
-     * @returns URL 是否可达
-     */
     private static async checkUrlWithCurl(url: string, timeout: number): Promise<boolean> {
         try {
-            // Windows 和 Linux/Mac 都支持 curl 命令
-            // -I: 只获取响应头
-            // -s: 静默模式，不显示进度条
-            // -o nul: 将输出丢弃到空设备
-            // --max-time: 设置最大超时时间（秒）
             const timeoutSec = Math.ceil(timeout / 1000)
             const nullDevice = process.platform === 'win32' ? 'nul' : '/dev/null'
             const command = `curl -I -s -o ${nullDevice} --max-time ${timeoutSec} "${url}"`
-
             await execAsync(command, { timeout })
             return true
         } catch {
@@ -62,18 +39,12 @@ export class NetworkDetector {
         }
     }
 
-    /**
-     * 检测网络是否可达
-     * @param options 检测选项
-     * @returns 检测结果
-     */
     static async check(options: NetworkCheckOptions = {}): Promise<NetworkCheckResult> {
         const startTime = Date.now()
         const { timeout = 1000, urls = this.DEFAULT_CHECK_URLS } = options
 
         const results: { url: string; reachable: boolean }[] = []
 
-        // 并行检测所有 URL（也可以改为串行，看需求）
         const checks = urls.map(async (url) => {
             const reachable = await this.checkUrlWithCurl(url, timeout)
             results.push({ url, reachable })
@@ -82,7 +53,7 @@ export class NetworkDetector {
         await Promise.allSettled(checks)
 
         const failedUrls = results.filter(r => !r.reachable).map(r => r.url)
-        const reachable = failedUrls.length < urls.length // 至少有一个可达就算网络可用
+        const reachable = failedUrls.length < urls.length
 
         return {
             reachable,
@@ -92,23 +63,11 @@ export class NetworkDetector {
         }
     }
 
-    /**
-     * 检测网络是否可达（简化版，只返回布尔值）
-     * @param options 检测选项
-     * @returns 网络是否可达
-     */
     static async isReachable(options: NetworkCheckOptions = {}): Promise<boolean> {
         const result = await this.check(options)
         return result.reachable
     }
 
-    /**
-     * 获取修正后的源顺序列表
-     * 如果网络不可达，自动回落到 ['local']
-     * @param sourceOrder 原始源顺序
-     * @param options 检测选项
-     * @returns 修正后的源顺序
-     */
     static async getSourceOrderWithFallback(
         sourceOrder: string[],
         options: NetworkCheckOptions = {}
@@ -116,11 +75,9 @@ export class NetworkDetector {
         const isNetworkOk = await this.isReachable(options)
 
         if (!isNetworkOk) {
-            // 网络不可达，只使用 local
             return ['local']
         }
 
-        // 网络可达，保持原有顺序
         return sourceOrder
     }
 }

--- a/src/util/NetworkDetector.ts
+++ b/src/util/NetworkDetector.ts
@@ -1,0 +1,126 @@
+import { exec } from 'child_process'
+import { promisify } from 'util'
+
+const execAsync = promisify(exec)
+
+/**
+ * 网络检测结果接口
+ */
+export interface NetworkCheckResult {
+    reachable: boolean
+    checkedUrls: string[]
+    failedUrls: string[]
+    checkTime: number
+}
+
+/**
+ * 网络检测配置接口
+ */
+export interface NetworkCheckOptions {
+    /** 超时时间（毫秒），默认 1000ms */
+    timeout?: number
+    /** 要检测的 URL 列表，默认使用查询引擎相关的 URL */
+    urls?: string[]
+    /** 是否使用代理，默认 false */
+    useProxy?: boolean
+}
+
+/**
+ * 网络检测器类
+ * 用于检测网络是否可达，支持自动回落到本地查询
+ */
+export class NetworkDetector {
+    /** 默认检测的 URL 列表（来自各查询引擎） */
+    private static readonly DEFAULT_CHECK_URLS = [
+        'https://trends.google.com', // Google Trends
+        'https://wikimedia.org', // Wikipedia
+        'https://www.reddit.com', // Reddit
+        'https://www.bing.com' // Bing（辅助 API）
+    ]
+
+    /**
+     * 使用 curl 检测单个 URL 是否可达
+     * @param url 要检测的 URL
+     * @param timeout 超时时间（毫秒）
+     * @returns URL 是否可达
+     */
+    private static async checkUrlWithCurl(url: string, timeout: number): Promise<boolean> {
+        try {
+            // Windows 和 Linux/Mac 都支持 curl 命令
+            // -I: 只获取响应头
+            // -s: 静默模式，不显示进度条
+            // -o nul: 将输出丢弃到空设备
+            // --max-time: 设置最大超时时间（秒）
+            const timeoutSec = Math.ceil(timeout / 1000)
+            const nullDevice = process.platform === 'win32' ? 'nul' : '/dev/null'
+            const command = `curl -I -s -o ${nullDevice} --max-time ${timeoutSec} "${url}"`
+
+            await execAsync(command, { timeout })
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    /**
+     * 检测网络是否可达
+     * @param options 检测选项
+     * @returns 检测结果
+     */
+    static async check(options: NetworkCheckOptions = {}): Promise<NetworkCheckResult> {
+        const startTime = Date.now()
+        const { timeout = 1000, urls = this.DEFAULT_CHECK_URLS } = options
+
+        const results: { url: string; reachable: boolean }[] = []
+
+        // 并行检测所有 URL（也可以改为串行，看需求）
+        const checks = urls.map(async (url) => {
+            const reachable = await this.checkUrlWithCurl(url, timeout)
+            results.push({ url, reachable })
+        })
+
+        await Promise.allSettled(checks)
+
+        const failedUrls = results.filter(r => !r.reachable).map(r => r.url)
+        const reachable = failedUrls.length < urls.length // 至少有一个可达就算网络可用
+
+        return {
+            reachable,
+            checkedUrls: urls,
+            failedUrls,
+            checkTime: Date.now() - startTime
+        }
+    }
+
+    /**
+     * 检测网络是否可达（简化版，只返回布尔值）
+     * @param options 检测选项
+     * @returns 网络是否可达
+     */
+    static async isReachable(options: NetworkCheckOptions = {}): Promise<boolean> {
+        const result = await this.check(options)
+        return result.reachable
+    }
+
+    /**
+     * 获取修正后的源顺序列表
+     * 如果网络不可达，自动回落到 ['local']
+     * @param sourceOrder 原始源顺序
+     * @param options 检测选项
+     * @returns 修正后的源顺序
+     */
+    static async getSourceOrderWithFallback(
+        sourceOrder: string[],
+        options: NetworkCheckOptions = {}
+    ): Promise<string[]> {
+        const isNetworkOk = await this.isReachable(options)
+
+        if (!isNetworkOk) {
+            // 网络不可达，只使用 local
+            return ['local']
+        }
+
+        // 网络可达，保持原有顺序
+        return sourceOrder
+    }
+}


### PR DESCRIPTION
  ## Summary
  This PR fixes two issues:
  1. Bing session verification fails for non-US regions (e.g., cn.bing.com)
  2. Adds network fallback feature - automatically falls back to local queries when network is unreachable

  ## Changes

  ### 1. Fix Bing Verification (`src/browser/auth/Login.ts`)
  - Changed hardcoded `www.bing.com` check to support all `*.bing.com` domains
  - Now supports `cn.bing.com`, `www.bing.com`, and other regional domains

  ### 2. Network Fallback Feature (New `src/util/NetworkDetector.ts`)
  - Uses curl to check network reachability (1 second timeout)
  - Automatically falls back to `local` queries when network is unreachable
  - Modified `QueryEngine.ts` to integrate network detection

  ### 3. Fix Browser Crash Issues (`src/browser/BrowserUtils.ts`)
  - Added page health checks
  - Changed concurrent clicking to serial to prevent crashes
  - Removed unstable wildcard selectors
  - Added crash detection and error handling

  ## Testing
  - Tested in debug mode
  - Bing session verification now works with cn.bing.com
  - Correctly falls back to local queries when network is restricted