### PR TITLE
retry search in case of slow internet speed

### DIFF
--- a/src/functions/activities/browser/Search.ts
+++ b/src/functions/activities/browser/Search.ts
@@ -60,9 +60,17 @@ export class Search extends Workers {
             const targetUrl = this.searchPageURL ? this.searchPageURL : this.bingHome
             this.bot.logger.debug(isMobile, 'SEARCH-BING', `Navigating to search page | url=${targetUrl}`)
 
-            await page.goto(targetUrl)
-            await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {})
-            await this.bot.browser.utils.tryDismissAllMessages(page)
+            for (let retry = 0; retry < 3; retry++) {
+                try {
+                    await page.goto(targetUrl)
+                    await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {})
+                    break
+                } catch (error) {
+                    if (retry === 2) throw error
+                    this.bot.logger.warn(isMobile, 'SEARCH-BING', `Failed to navigate to target URL, retrying...`)
+                    await this.bot.utils.wait(2000)
+                }
+            }
 
             let stagnantLoop = 0
             const stagnantLoopMax = 10


### PR DESCRIPTION
i have an bad isp, so my internet has a lot of latency and stability issues, and this make some of my accounts skip searching, witch is bad.
<img width="1326" height="199" alt="Captura de Tela 2026-03-21 às 21 56 58" src="https://github.com/user-attachments/assets/50137cae-b927-473f-83d5-0c73c57765f8" />
