### PR TITLE
fix: improve daily check-in to use correct Android app payload (up to 50pts vs fixed 5pts)

### DIFF
--- a/src/functions/activities/app/DailyCheckIn.ts
+++ b/src/functions/activities/app/DailyCheckIn.ts
@@ -26,55 +26,19 @@ export class DailyCheckIn extends Workers {
         )
 
         try {
-            // Try type 101 first
-            this.bot.logger.debug(this.bot.isMobile, 'DAILY-CHECK-IN', 'Attempting Daily Check-In | type=101')
-
-            let response = await this.submitDaily(101) // Try using 101 (EU Variant?)
-            this.bot.logger.debug(
-                this.bot.isMobile,
-                'DAILY-CHECK-IN',
-                `Received Daily Check-In response | type=101 | status=${response?.status ?? 'unknown'}`
-            )
-
-            let newBalance = Number(response?.data?.response?.balance ?? this.oldBalance)
-            this.gainedPoints = newBalance - this.oldBalance
-
-            this.bot.logger.debug(
-                this.bot.isMobile,
-                'DAILY-CHECK-IN',
-                `Balance delta after Daily Check-In | type=101 | oldBalance=${this.oldBalance} | newBalance=${newBalance} | gainedPoints=${this.gainedPoints}`
-            )
-
-            if (this.gainedPoints > 0) {
-                this.bot.userData.currentPoints = newBalance
-                this.bot.userData.gainedPoints = (this.bot.userData.gainedPoints ?? 0) + this.gainedPoints
-
-                this.bot.logger.info(
-                    this.bot.isMobile,
-                    'DAILY-CHECK-IN',
-                    `Completed Daily Check-In | type=101 | gainedPoints=${this.gainedPoints} | oldBalance=${this.oldBalance} | newBalance=${newBalance}`,
-                    'green'
-                )
-                return
-            }
-
-            this.bot.logger.debug(
-                this.bot.isMobile,
-                'DAILY-CHECK-IN',
-                `No points gained with type=101 | oldBalance=${this.oldBalance} | newBalance=${newBalance} | retryingWithType=103`
-            )
-
-            // Fallback to type 103
+            // type=103 found in Bing Android APK rewards miniapp (services.js: g=103, called as LS(HG))
+            // Payload matches miniapp: empty attributes, channel=SAAndroid, risk_context={}
+            // Headers match miniapp: X-Rewards-PartnerId=startapp, X-Rewards-Flights=rwgobig
             this.bot.logger.debug(this.bot.isMobile, 'DAILY-CHECK-IN', 'Attempting Daily Check-In | type=103')
 
-            response = await this.submitDaily(103) // Try using 103 (USA Variant?)
+            const response = await this.submitDaily(103)
             this.bot.logger.debug(
                 this.bot.isMobile,
                 'DAILY-CHECK-IN',
                 `Received Daily Check-In response | type=103 | status=${response?.status ?? 'unknown'}`
             )
 
-            newBalance = Number(response?.data?.response?.balance ?? this.oldBalance)
+            const newBalance = Number(response?.data?.response?.balance ?? this.oldBalance)
             this.gainedPoints = newBalance - this.oldBalance
 
             this.bot.logger.debug(
@@ -97,7 +61,7 @@ export class DailyCheckIn extends Workers {
                 this.bot.logger.warn(
                     this.bot.isMobile,
                     'DAILY-CHECK-IN',
-                    `Daily Check-In completed but no points gained | typesTried=101,103 | oldBalance=${this.oldBalance} | finalBalance=${newBalance}`
+                    `Daily Check-In completed but no points gained | type=103 | oldBalance=${this.oldBalance} | finalBalance=${newBalance}`
                 )
             }
         } catch (error) {
@@ -115,16 +79,16 @@ export class DailyCheckIn extends Workers {
                 id: randomUUID(),
                 amount: 1,
                 type: type,
-                attributes: {
-                    offerid: 'Gamification_Sapphire_DailyCheckIn'
-                },
-                country: this.bot.userData.geoLocale
+                attributes: {},
+                country: this.bot.userData.geoLocale,
+                risk_context: {},
+                channel: 'SAAndroid'
             }
 
             this.bot.logger.debug(
                 this.bot.isMobile,
                 'DAILY-CHECK-IN',
-                `Preparing Daily Check-In payload | type=${type} | id=${jsonData.id} | amount=${jsonData.amount} | country=${jsonData.country}`
+                `Preparing Daily Check-In payload | type=${type} | id=${jsonData.id} | amount=${jsonData.amount} | country=${jsonData.country} | channel=${jsonData.channel}`
             )
 
             const request: AxiosRequestConfig = {
@@ -133,11 +97,14 @@ export class DailyCheckIn extends Workers {
                 headers: {
                     Authorization: `Bearer ${this.bot.accessToken}`,
                     'User-Agent':
-                        'Bing/32.5.431027001 (com.microsoft.bing; build:431027001; iOS 17.6.1) Alamofire/5.10.2',
+                        'Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Mobile Safari/537.36 BingSapphire/32.8.4402280014',
                     'Content-Type': 'application/json',
                     'X-Rewards-Country': this.bot.userData.geoLocale,
                     'X-Rewards-Language': 'en',
-                    'X-Rewards-ismobile': 'true'
+                    'X-Rewards-AppId': 'SAAndroid/32.8.4402280014',
+                    'X-Rewards-IsMobile': 'true',
+                    'X-Rewards-PartnerId': 'startapp',
+                    'X-Rewards-Flights': 'rwgobig'
                 },
                 data: JSON.stringify(jsonData)
             }


### PR DESCRIPTION
The original daily check-in used type=101 with offerid in attributes, always giving ~5 points flat. By analyzing the rewards miniapp JS bundled in the Bing Android APK, found the correct payload that the Android app uses, which follows the weekly streak system (5-50 points depending on day of the week, up to 50pts on the final day).

**Root cause:**
- `attributes` must be `{}` (not `{offerid: "Gamification_Sapphire_DailyCheckIn"}`)
- Missing `risk_context: {}` and `channel: "SAAndroid"` in the request body
- Missing headers: `X-Rewards-AppId`, `X-Rewards-PartnerId`, `X-Rewards-Flights`
- User-Agent updated to Android BingSapphire

**Source:** `resources/assets/miniapps/rewards/js/services.c6493198.js` + `utils.e3002795.js` inside the Bing Android APK
- `g = 103` -> check-in type constant
- Body built by `Kn()`: `{amount:1, attributes:{}, id:UUID, type:103, country, risk_context:{}, channel:"SAAndroid"}`
- Extra headers from `app.492cb5d3.js`: `X-Rewards-PartnerId: startapp`, `X-Rewards-Flights: rwgobig`

**Note on type=101:** It has been removed since it always returned 5 points flat and - due to the early `return` - prevented type=103 from ever running. If you prefer to keep a fallback, the suggested order would be 103 first (streak-based, 5-50pts) -> fallback to 101 (always 5pts), rather than the original 101->103 which made type=103 unreachable.

**Tested:** confirmed working on 05/04/2026.