### PR TITLE
Fix hang in docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,7 @@ RUN rm -rf node_modules \
     && npm cache clean --force
 
 # Install Chromium Headless Shell, and cleanup
-RUN npx patchright install --with-deps --only-shell chromium \
-    && rm -rf /root/.cache /tmp/* /var/tmp/*
+RUN npx patchright install --with-deps --only-shell chromium 
 
 ###############################################################################
 # Stage 2: Runtime


### PR DESCRIPTION
Removed the extra cleanup step in the builder stage `\    && rm -rf /root/.cache /tmp/* /var/tmp/*` which seemed to cause the docker image build to get stuck indefinitely after downloading patchright chromium. 
