### PR TITLE
fix: bypass passwordless login when totpSecret is configured

### DIFF
--- a/src/browser/auth/Login.ts
+++ b/src/browser/auth/Login.ts
@@ -496,6 +496,38 @@ export class Login {
             }
 
             case 'LOGIN_PASSWORDLESS': {
+                // If totpSecret is configured, bypass passwordless to reach the TOTP code entry page
+                if (account.totpSecret) {
+                    this.bot.logger.info(
+                        this.bot.isMobile,
+                        'LOGIN',
+                        'TOTP secret configured, attempting to bypass passwordless flow'
+                    )
+
+                    const otherWaysLink = await page
+                        .waitForSelector(this.selectors.otherWaysToSignIn, { state: 'visible', timeout: 3000 })
+                        .catch(() => null)
+
+                    if (otherWaysLink) {
+                        this.bot.logger.info(this.bot.isMobile, 'LOGIN', 'Found "Other ways to sign in" link')
+                        await this.bot.browser.utils.ghostClick(page, this.selectors.otherWaysToSignIn)
+                        await page.waitForLoadState('networkidle', { timeout: 5000 }).catch(() => {
+                            this.bot.logger.debug(
+                                this.bot.isMobile,
+                                'LOGIN',
+                                'Network idle timeout after clicking other ways'
+                            )
+                        })
+                        return true
+                    }
+
+                    this.bot.logger.warn(
+                        this.bot.isMobile,
+                        'LOGIN',
+                        'Could not find "Other ways to sign in", falling back to manual approval'
+                    )
+                }
+
                 this.bot.logger.info(this.bot.isMobile, 'LOGIN', 'Handling passwordless authentication')
                 await this.passwordlessLogin.handle(page)
                 await page.waitForLoadState('networkidle', { timeout: 5000 }).catch(() => {


### PR DESCRIPTION
## Problem

When a user has configured `totpSecret` in `accounts.json` for automatic TOTP 2FA, the script ignores it if Microsoft presents the passwordless (Authenticator push notification with number matching) page. The `LOGIN_PASSWORDLESS` handler only waits passively for manual approval, with no attempt to switch to the TOTP entry method.

This is especially problematic because Microsoft may skip the password entry step entirely for some accounts, going straight from email input to the Authenticator push notification page.

## Root Cause

The `LOGIN_PASSWORDLESS` handler in `Login.ts` calls `PasswordlessLogin.handle()` which only:
1. Reads the displayed number
2. Prints a log asking the user to manually approve
3. Waits up to 60 seconds for URL change

Unlike `GET_A_CODE` and `OTP_CODE_ENTRY` handlers which actively try to bypass the current page by clicking "Other ways to sign in", the passwordless handler has no such bypass logic.

## Fix

When `totpSecret` is configured, the `LOGIN_PASSWORDLESS` handler now:

1. Detects that TOTP secret is available
2. Clicks the existing `"Other ways to sign in"` link (reuses `otherWaysToSignIn` selector)
3. Returns control to the state machine loop
4. The state machine naturally detects `SIGN_IN_ANOTHER_WAY` → clicks `"Use your password"`
5. Then `PASSWORD_INPUT` → enters password
6. Then `2FA_TOTP` → auto-fills TOTP code from the secret

If the bypass fails (e.g., "Other ways to sign in" link not found), it gracefully falls back to the original manual approval flow.

## Verified State Flow

```
LOGIN_PASSWORDLESS → (click "Other ways to sign in") →
SIGN_IN_ANOTHER_WAY → (click "Use my password") →
PASSWORD_INPUT → (enter password) →
2FA_TOTP → (auto-fill TOTP code)
```

Tested with MCP-connected browser debugging against a live account. Log output:

```
State transition: EMAIL_INPUT → LOGIN_PASSWORDLESS
TOTP secret configured, attempting to bypass passwordless flow
Found "Other ways to sign in" link
State transition: LOGIN_PASSWORDLESS → SIGN_IN_ANOTHER_WAY
Selecting "Use my password"
State transition: SIGN_IN_ANOTHER_WAY → PASSWORD_INPUT
Entering password
```

## Changes

- `src/browser/auth/Login.ts` — Added totpSecret bypass in `LOGIN_PASSWORDLESS` handler
- `.gitignore` — Added `.mcp.json` and `.claude/` (project tooling files)