### PR TITLE
Update compose.yaml to use prebuilt image instead of build. Fix formatting in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,9 @@ ACCOUNT_1_PASSWORD=your_password
 > To update, delete `./config/config.json` and restart — a fresh one will be generated from the latest example, with your `compose.yaml` overrides re-applied.
 
 - Start the container: `docker compose up -d`
-    > [!TIP]
-    > Monitor logs with `docker logs microsoft-rewards-script`, useful for viewing passwordless login codes or diagnosing issues.
-    > You can also enable a webhook in `compose.yaml` for notifications.
+> [!TIP]
+> Monitor logs with `docker logs microsoft-rewards-script`, useful for viewing passwordless login codes or diagnosing issues.
+> You can also enable a webhook in `compose.yaml` for notifications.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ ACCOUNT_1_PASSWORD=your_password
 > [!WARNING]
 > Do **not** skip this step if you are running the script bare metal.
 
-- **Bare metal:**: Copy or rename `config.example.json` to `config.json` (in the project root) and customize your preferences.
+- **Bare metal:** Copy or rename `config.example.json` to `config.json` (in the project root) and customize your preferences.
 - **Docker:** A valid `config.json` is automatically created on first run and saved locally to `./config/`. You can optionally manually create a `config.json` (e.g., if you need to specify regex values) using the provided `config.example.json`
 
 > [!CAUTION]
@@ -100,11 +100,12 @@ ACCOUNT_1_PASSWORD=your_password
 ```
 
 - Review `compose.yaml` to adjust scheduling, timezone, and config options.
-    > [!NOTE]
-    > A valid `config.json` is auto-generated on first run using default values, and saved locally to `./config/`.
-    > Optionally, use `CONFIG_*` variables in the `environment:` section of the `compose.yaml` to customise your options (e.g., clusters, webhook, etc.).
-    > A full list of available options are in the [table below](#configuration-options).
-    > `CONFIG_*` variables are applied on every startup and always take precedence over `./config/config.json`.
+  
+> [!NOTE]
+> A valid `config.json` is auto-generated on first run using default values, and saved locally to `./config/`.
+> Optionally, use `CONFIG_*` variables in the `environment:` section of the `compose.yaml` to customise your options (e.g., clusters, webhook, etc.).
+> A full list of available options are in the [table below](#configuration-options).
+> `CONFIG_*` variables are applied on every startup and always take precedence over `./config/config.json`.
 
 > [!TIP]
 > If a new image adds config options you're missing, a warning will appear in the container logs.

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,9 +1,9 @@
 services:
     microsoft-rewards-script:
-        # image: ghcr.io/thenetsky/microsoft-rewards-script:latest
+        image: ghcr.io/thenetsky/microsoft-rewards-script:latest
         # To build locally instead of pulling the prebuilt image, use the build section below.
-        build:
-            context: .
+        #build:
+        #    context: .
         container_name: microsoft-rewards-script
         restart: unless-stopped
         volumes:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
     microsoft-rewards-script:
-        image: ghcr.io/thenetsky/microsoft-rewards-script:latest
+        image: ghcr.io/thenetsky/microsoft-rewards-script:4
         # To build locally instead of pulling the prebuilt image, use the build section below.
         #build:
         #    context: .


### PR DESCRIPTION
The v4 compose.yaml can use `image:...` now that there's a prebuilt v4+ image available and no longer requires a local `build:...`. Updated that. Also updated a few callouts in the readme. No new release required, just maintenance.