### PR TITLE
Pin v3 to last working v3 version prior to v4

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
     microsoft-rewards-script:
-        image: ghcr.io/thenetsky/microsoft-rewards-script:latest
+        image: ghcr.io/thenetsky/microsoft-rewards-script:3.1.6
         container_name: microsoft-rewards-script
         restart: unless-stopped
         volumes:


### PR DESCRIPTION
v4 now uses the `latest` tag, this pins the version for v3 users who do not have the new dash