### PR TITLE
Add API control of docker scheduler

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -16,11 +16,9 @@ services:
             # ── Scheduler ──────────────────────────────────────
             TZ: 'America/Toronto'
             NODE_ENV: 'production'
-            # CRON_SCHEDULE is only the *initial* default. Once a schedule is
-            # saved via PUT /schedule (e.g. from the dashboard's Schedule tab
-            # with "Bot container" selected), it's persisted to
-            # ./config/schedule.json and takes over from here on — delete
-            # that file to fall back to CRON_SCHEDULE again.
+            # CRON_SCHEDULE is the *initial* default. It will run as default unless changed by the API
+            # API schedule changes are saved to ./config/schedule.json, delete
+            # that file to revert to the base CRON_SCHEDULE again.
             CRON_SCHEDULE: '0 7 * * *' # use crontab.guru to customize your schedule
             RUN_ON_START: 'true' # run script immediately on container start
             SKIP_RANDOM_SLEEP: 'false'
@@ -37,12 +35,6 @@ services:
             #API_ALLOW_ENV_OVERRIDES: 'true'
             #API_ALLOW_CONFIG_REVEAL: 'true'
             #API_ALLOW_CONFIG_WRITE: 'true'
-
-            # Set true to let the dashboard (or any Control API client) read
-            # and rewrite this container's own cron schedule live, no restart
-            # needed. Off by default — writing to cron is a step up in trust
-            # from just starting/stopping runs.
-            #API_ALLOW_SCHEDULE_WRITE: 'true'
 
             #  ── Configuration ──────────────────────────────────────
             # Uncomment to override defaults, a full list of configuration options are in the README.

--- a/compose.yaml
+++ b/compose.yaml
@@ -30,7 +30,7 @@ services:
             # Set API_MODE=true to run the API server for additional control options
             #API_MODE: 'true'
             #API_TOKEN: '${API_TOKEN}'             # required for API mode, see example.env
-            # set the API_ALLOW=true to enable API commands to make changes to the script configuration
+            # set the API_ALLOW=true to enable API commands to make changes to the script configuration, off by default
             #API_ALLOW_SCHEDULE_WRITE: 'true'
             #API_ALLOW_ENV_OVERRIDES: 'true'
             #API_ALLOW_CONFIG_REVEAL: 'true'

--- a/compose.yaml
+++ b/compose.yaml
@@ -16,6 +16,11 @@ services:
             # ── Scheduler ──────────────────────────────────────
             TZ: 'America/Toronto'
             NODE_ENV: 'production'
+            # CRON_SCHEDULE is only the *initial* default. Once a schedule is
+            # saved via PUT /schedule (e.g. from the dashboard's Schedule tab
+            # with "Bot container" selected), it's persisted to
+            # ./config/schedule.json and takes over from here on — delete
+            # that file to fall back to CRON_SCHEDULE again.
             CRON_SCHEDULE: '0 7 * * *' # use crontab.guru to customize your schedule
             RUN_ON_START: 'true' # run script immediately on container start
             SKIP_RANDOM_SLEEP: 'false'
@@ -27,6 +32,17 @@ services:
             # Set API_MODE=true to run the API server for additional control options
             #API_MODE: 'true'
             #API_TOKEN: '${API_TOKEN}'             # required for API mode, see example.env
+            # set the API_ALLOW=true to enable API commands to make changes to the script configuration
+            #API_ALLOW_SCHEDULE_WRITE: 'true'
+            #API_ALLOW_ENV_OVERRIDES: 'true'
+            #API_ALLOW_CONFIG_REVEAL: 'true'
+            #API_ALLOW_CONFIG_WRITE: 'true'
+
+            # Set true to let the dashboard (or any Control API client) read
+            # and rewrite this container's own cron schedule live, no restart
+            # needed. Off by default — writing to cron is a step up in trust
+            # from just starting/stopping runs.
+            #API_ALLOW_SCHEDULE_WRITE: 'true'
 
             #  ── Configuration ──────────────────────────────────────
             # Uncomment to override defaults, a full list of configuration options are in the README.

--- a/scripts/api/apply-schedule.js
+++ b/scripts/api/apply-schedule.js
@@ -1,0 +1,29 @@
+/**
+ * Applies a persisted config/schedule.json override to the live crontab at
+ * container startup. Called by entrypoint.sh in API_MODE=true, only when
+ * schedule.json exists (i.e. the dashboard has saved a remote schedule at
+ * least once) — bots that only ever use CRON_SCHEDULE never touch this file
+ * and take the existing envsubst path in entrypoint.sh instead.
+ */
+
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { getProjectRoot } from './lib.js'
+import { readSchedule, applyCrontab } from './scheduleStore.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const projectRoot = getProjectRoot(__dirname)
+
+try {
+    const schedule = readSchedule(projectRoot)
+    if (schedule.enabled && schedule.cron) {
+        applyCrontab(schedule)
+        console.log(`[apply-schedule] Applied schedule.json override: "${schedule.cron}" (TZ=${schedule.timezone})`)
+    } else {
+        console.log('[apply-schedule] schedule.json override present but disabled — no crontab installed.')
+    }
+} catch (err) {
+    console.error(`[apply-schedule] ERROR: ${err instanceof Error ? err.message : err}`)
+    process.exit(1)
+}

--- a/scripts/api/scheduleStore.js
+++ b/scripts/api/scheduleStore.js
@@ -1,0 +1,185 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { execFileSync } from 'node:child_process'
+
+// Kept in sync with rewards-dashboard/lib/cron.js's isValidCron — same
+// 5-field grammar. Duplicated here because the bot and dashboard are
+// separate projects that don't share a package.
+const CRON_FIELD_RANGES = [
+    { min: 0, max: 59 }, // minute
+    { min: 0, max: 23 }, // hour
+    { min: 1, max: 31 }, // day of month
+    { min: 1, max: 12 }, // month
+    { min: 0, max: 7 }   // day of week (7 == Sunday)
+]
+
+function validateField(expr, { min, max }) {
+    if (expr === '*') return true
+    for (const part of expr.split(',')) {
+        const stepSplit = part.split('/')
+        if (stepSplit.length > 2) return false
+
+        const step = stepSplit.length === 2 ? Number(stepSplit[1]) : 1
+        if (!Number.isInteger(step) || step < 1) return false
+
+        const range = stepSplit[0]
+        let lo
+        let hi
+        if (range === '*') {
+            lo = min
+            hi = max
+        } else if (range.includes('-')) {
+            const [a, b] = range.split('-')
+            lo = Number(a)
+            hi = Number(b)
+        } else {
+            lo = Number(range)
+            hi = Number(range)
+        }
+        if (!Number.isInteger(lo) || !Number.isInteger(hi)) return false
+        if (lo < min || hi > max || lo > hi) return false
+    }
+    return true
+}
+
+export function isValidCron(expr) {
+    if (typeof expr !== 'string') return false
+    const parts = expr.trim().split(/\s+/)
+    if (parts.length !== 5) return false
+    return parts.every((part, i) => validateField(part, CRON_FIELD_RANGES[i]))
+}
+
+// The override file lives inside the ./config bind mount that's already
+// mounted by compose_bot.yaml, so no new volume is required to persist it
+// across container restarts.
+export function scheduleFilePath(projectRoot) {
+    return process.env.SCHEDULE_FILE || path.join(projectRoot, 'config', 'schedule.json')
+}
+
+/**
+ * Returns the effective schedule: the persisted override if one has been
+ * written via PUT /schedule, otherwise the CRON_SCHEDULE env var as set at
+ * container start (so a bot with no frontend attached still reports something
+ * sensible, and reports it as `source: 'env'` so callers know it isn't live-editable
+ * without first calling PUT).
+ */
+export function readSchedule(projectRoot) {
+    const file = scheduleFilePath(projectRoot)
+    if (fs.existsSync(file)) {
+        let saved
+        try {
+            saved = JSON.parse(fs.readFileSync(file, 'utf8'))
+        } catch (err) {
+            throw Object.assign(new Error(`schedule.json is corrupt: ${err.message}`), { code: 'CORRUPT_SCHEDULE' })
+        }
+        return {
+            enabled: Boolean(saved.enabled),
+            cron: typeof saved.cron === 'string' ? saved.cron : null,
+            skipIfRunning: saved.skipIfRunning !== false,
+            excludedAccountIndexes: Array.isArray(saved.excludedAccountIndexes)
+                ? saved.excludedAccountIndexes.filter(n => Number.isInteger(n) && n >= 1)
+                : [],
+            updatedAt: saved.updatedAt || null,
+            timezone: process.env.TZ || 'UTC',
+            source: 'override'
+        }
+    }
+    return {
+        enabled: Boolean(process.env.CRON_SCHEDULE),
+        cron: process.env.CRON_SCHEDULE || null,
+        skipIfRunning: true,
+        excludedAccountIndexes: [],
+        updatedAt: null,
+        timezone: process.env.TZ || 'UTC',
+        source: 'env'
+    }
+}
+
+export function writeSchedule(projectRoot, patch) {
+    const current = readSchedule(projectRoot)
+    const next = { ...current }
+
+    if ('cron' in patch) {
+        if (typeof patch.cron !== 'string' || !isValidCron(patch.cron)) {
+            throw Object.assign(
+                new Error('Invalid cron expression (5 fields, e.g. "0 9 * * *").'),
+                { code: 'BAD_REQUEST' }
+            )
+        }
+        next.cron = patch.cron.trim()
+    }
+    if ('enabled' in patch) next.enabled = Boolean(patch.enabled)
+    if ('skipIfRunning' in patch) next.skipIfRunning = Boolean(patch.skipIfRunning)
+    if ('excludedAccountIndexes' in patch) {
+        if (!Array.isArray(patch.excludedAccountIndexes)) {
+            throw Object.assign(new Error('excludedAccountIndexes must be an array.'), { code: 'BAD_REQUEST' })
+        }
+        const indexes = [...new Set(patch.excludedAccountIndexes.map(Number))]
+        if (indexes.some(i => !Number.isSafeInteger(i) || i < 1)) {
+            throw Object.assign(
+                new Error('excludedAccountIndexes must contain only positive integers.'),
+                { code: 'BAD_REQUEST' }
+            )
+        }
+        next.excludedAccountIndexes = indexes.sort((a, b) => a - b)
+    }
+    if (next.enabled && !next.cron) {
+        throw Object.assign(new Error('Cannot enable the schedule without a cron expression.'), { code: 'BAD_REQUEST' })
+    }
+
+    next.updatedAt = new Date().toISOString()
+    next.timezone = process.env.TZ || 'UTC'
+    delete next.source
+
+    const file = scheduleFilePath(projectRoot)
+    fs.mkdirSync(path.dirname(file), { recursive: true })
+    const tmp = `${file}.${process.pid}.tmp`
+    fs.writeFileSync(tmp, JSON.stringify(next, null, 2))
+    fs.renameSync(tmp, file)
+
+    applyCrontab(next)
+
+    return { ...next, source: 'override' }
+}
+
+const CRON_FILE = '/etc/cron.d/microsoft-rewards-cron'
+const CRON_TEMPLATE = '/etc/cron.d/microsoft-rewards-cron.template'
+
+/**
+ * Renders the crontab template with the given schedule and loads it live via
+ * `crontab <file>` — the same mechanism entrypoint.sh uses at startup, which
+ * is why cron picks it up without a container restart. Note the template has
+ * no `user` field, so it's only valid when loaded via `crontab`, not via
+ * cron.d's own directory auto-scan.
+ */
+export function applyCrontab({ enabled, cron }) {
+    if (!enabled || !cron) {
+        try {
+            execFileSync('crontab', ['-r'], { stdio: 'ignore' })
+        } catch {
+            // nothing to remove — fine
+        }
+        try {
+            fs.unlinkSync(CRON_FILE)
+        } catch {
+            // already gone — fine
+        }
+        return
+    }
+
+    if (!fs.existsSync(CRON_TEMPLATE)) {
+        throw Object.assign(
+            new Error(`Cron template not found at ${CRON_TEMPLATE} — image may be corrupt.`),
+            { code: 'TEMPLATE_MISSING' }
+        )
+    }
+
+    const tz = process.env.TZ || 'UTC'
+    const rendered = fs
+        .readFileSync(CRON_TEMPLATE, 'utf8')
+        .replace(/\$\{CRON_SCHEDULE\}/g, cron)
+        .replace(/\$\{TZ\}/g, tz)
+
+    fs.writeFileSync(CRON_FILE, rendered, { mode: 0o644 })
+    execFileSync('crontab', [CRON_FILE])
+}

--- a/scripts/api/server.js
+++ b/scripts/api/server.js
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url'
 import { ProcessManager } from './processManager.js'
 import { buildExcludedAccountsEnv, buildSingleAccountEnv, loadAccounts, mergeAccountStats } from './accounts.js'
 import { validateConfig, deepMerge, readConfig, writeConfigAtomic } from './configEditor.js'
+import { readSchedule, writeSchedule } from './scheduleStore.js'
 import { resolveRunCommand } from './runCommand.js'
 import {
     log,
@@ -33,7 +34,7 @@ try {
     const pkg = JSON.parse(fs.readFileSync(path.join(projectRoot, 'package.json'), 'utf8'))
     pkgVersion = pkg.version ?? pkgVersion
     pkgName = pkg.name ?? pkgName
-} catch {}
+} catch { }
 
 const HOST = envStr('API_HOST') ?? (typeof cliArgs.host === 'string' ? cliArgs.host : '127.0.0.1')
 const PORT = Number(cliArgs.port) || envInt('API_PORT', 3010)
@@ -44,6 +45,10 @@ const STOP_TIMEOUT_MS = envInt('API_STOP_TIMEOUT_MS', 15000)
 const ALLOW_ENV_OVERRIDES = envBool('API_ALLOW_ENV_OVERRIDES', false)
 const REVEAL_ENABLED = envBool('API_ALLOW_CONFIG_REVEAL', false)
 const ALLOW_CONFIG_WRITE = envBool('API_ALLOW_CONFIG_WRITE', false)
+// Writing to the crontab is a meaningfully different trust level than
+// starting/stopping a run, so it gets its own opt-in flag rather than
+// riding along with API_MODE=true for free.
+const ALLOW_SCHEDULE_WRITE = envBool('API_ALLOW_SCHEDULE_WRITE', false)
 
 const RUN_HISTORY = envInt('API_RUN_HISTORY', 20)
 const DIAG_DIR = envStr('API_DIAGNOSTICS_DIR') ?? path.join(projectRoot, 'diagnostics')
@@ -247,11 +252,13 @@ const requestHandler = async (req, res) => {
                     'GET /diagnostics',
                     'GET /events',
                     'GET /config',
+                    'GET /schedule',
                     'POST /start',
                     'POST /stop',
                     'POST /restart',
                     'POST /shutdown',
-                    'PUT|PATCH /config'
+                    'PUT|PATCH /config',
+                    'PUT|PATCH /schedule'
                 ]
             })
         }
@@ -331,6 +338,39 @@ const requestHandler = async (req, res) => {
             return sendJson(res, 200, { path: loaded.path, redacted: !reveal, config: data })
         }
 
+        // sched read
+        if (method === 'GET' && pathname === '/schedule') {
+            try {
+                return sendJson(res, 200, { ...readSchedule(projectRoot), writable: ALLOW_SCHEDULE_WRITE })
+            } catch (err) {
+                return sendJson(res, 500, { error: err.message, code: err.code })
+            }
+        }
+
+        // sched write
+        if ((method === 'PUT' || method === 'PATCH') && pathname === '/schedule') {
+            if (!ALLOW_SCHEDULE_WRITE) {
+                return sendJson(res, 403, {
+                    error: 'Schedule writes are disabled. Set API_ALLOW_SCHEDULE_WRITE=true to enable.'
+                })
+            }
+            const body = await readJsonBody(req)
+            if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+                return sendJson(res, 400, { error: 'Body must be a JSON object.' })
+            }
+            try {
+                const updated = writeSchedule(projectRoot, body)
+                pm.note(
+                    'info',
+                    `Schedule updated via API (${method}): ${updated.enabled ? `${updated.cron} (TZ ${updated.timezone})` : 'disabled'}.`
+                )
+                return sendJson(res, 200, { ...updated, writable: true })
+            } catch (err) {
+                const status = err.code === 'BAD_REQUEST' ? 400 : 500
+                return sendJson(res, status, { error: err.message, code: err.code })
+            }
+        }
+
         // sse
         if (method === 'GET' && pathname === '/events') {
             return handleEventStream(req, res, url)
@@ -382,7 +422,7 @@ const requestHandler = async (req, res) => {
             const force = Boolean(body.force)
             try {
                 const stopping = pm.stop({ force })
-                stopping.catch(() => {})
+                stopping.catch(() => { })
                 return sendJson(res, 202, { stopping: true, force })
             } catch (err) {
                 if (err.code === 'NOT_RUNNING') return sendJson(res, 409, { error: err.message, code: err.code })
@@ -514,14 +554,14 @@ function listDiagnostics() {
             let error = null
             try {
                 files = fs.readdirSync(full)
-            } catch {}
+            } catch { }
             try {
                 createdAt = fs.statSync(full).mtime.toISOString()
-            } catch {}
+            } catch { }
             if (files.includes('error.txt')) {
                 try {
                     error = fs.readFileSync(path.join(full, 'error.txt'), 'utf8').slice(0, 2000)
-                } catch {}
+                } catch { }
             }
             return {
                 name: d.name,
@@ -573,7 +613,10 @@ server.listen(PORT, HOST, () => {
         'INFO',
         `Auth: ${TOKEN ? 'shared token required (API_TOKEN)' : 'DISABLED (no API_TOKEN set)'} | CORS origin: ${CORS_ORIGIN}`
     )
-    log('INFO', `Stateless: writes nothing to disk | config writes: ${ALLOW_CONFIG_WRITE ? 'on' : 'off'}`)
+    log(
+        'INFO',
+        `Stateless: writes nothing to disk except schedule.json when enabled | config writes: ${ALLOW_CONFIG_WRITE ? 'on' : 'off'} | schedule writes: ${ALLOW_SCHEDULE_WRITE ? 'on' : 'off'}`
+    )
     if (!TOKEN) {
         const loopback = HOST === '127.0.0.1' || HOST === 'localhost' || HOST === '::1'
         log(

--- a/scripts/api/trigger.js
+++ b/scripts/api/trigger.js
@@ -10,6 +10,14 @@
  */
 
 import http from 'node:http'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { getProjectRoot } from './lib.js'
+import { readSchedule } from './scheduleStore.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const projectRoot = getProjectRoot(__dirname)
 
 const PORT = Number(process.env.API_PORT) || 3010
 const TOKEN = process.env.API_TOKEN || ''
@@ -18,9 +26,10 @@ const POLL_MS = 15_000
 const STARTUP_ATTEMPTS = 30
 const STARTUP_DELAY_MS = 2_000
 
-function request(method, path) {
+function request(method, path, body = {}) {
     return new Promise((resolve, reject) => {
-        const headers = { 'Content-Type': 'application/json', 'Content-Length': '2' }
+        const payload = JSON.stringify(body ?? {})
+        const headers = { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(payload) }
         if (TOKEN) headers['Authorization'] = `Bearer ${TOKEN}`
         const req = http.request({ host: '127.0.0.1', port: PORT, path, method, headers }, res => {
             let raw = ''
@@ -34,12 +43,29 @@ function request(method, path) {
             })
         })
         req.on('error', reject)
-        req.end('{}')
+        req.end(payload)
     })
 }
 
 function sleep(ms) {
     return new Promise(r => setTimeout(r, ms))
+}
+
+// Scheduled runs (cron -> run_daily.sh -> here) honor whichever accounts are
+// currently excluded in config/schedule.json, if the dashboard (or a manual
+// PUT /schedule call) has ever saved one. RUN_ON_START's initial kickoff goes
+// through this same path, so it respects exclusions too rather than always
+// running every account regardless of the saved schedule.
+function buildStartBody() {
+    try {
+        const schedule = readSchedule(projectRoot)
+        if (schedule.excludedAccountIndexes?.length) {
+            return { excludedAccountIndexes: schedule.excludedAccountIndexes }
+        }
+    } catch (err) {
+        console.warn(`[trigger] Could not read schedule.json, running with all accounts: ${err.message}`)
+    }
+    return {}
 }
 
 // Wait for the API server to be ready.  Handles the RUN_ON_START race where
@@ -67,7 +93,7 @@ if (!ready) {
 }
 
 // Trigger the run.
-const { status, body } = await request('POST', '/start')
+const { status, body } = await request('POST', '/start', buildStartBody())
 
 if (status === 409) {
     // A run is already in progress — the dashboard or a previous cron invocation

--- a/scripts/docker/entrypoint.sh
+++ b/scripts/docker/entrypoint.sh
@@ -340,24 +340,44 @@ export API_HOST
 if [ "${API_MODE:-false}" = "true" ]; then
   # API-integrated mode:
   #   - The API server is the main (foreground) process and becomes PID 1.
-  #   - If CRON_SCHEDULE is set, cron also runs as a background daemon.
+  #   - The cron schedule can come from two places, checked in this order:
+  #       1. config/schedule.json — a persisted override written by
+  #          PUT /schedule (e.g. from the dashboard). Present only if that
+  #          endpoint has been used at least once; survives restarts because
+  #          it lives in the ./config bind mount.
+  #       2. CRON_SCHEDULE — the env var, exactly as before. This remains the
+  #          only thing that matters for anyone not using PUT /schedule.
+  #   - Either way, if a schedule is active, cron runs as a background daemon;
   #     run_daily.sh detects API_MODE=true and calls POST /start via
   #     scripts/api/trigger.js instead of running npm start directly, so the
   #     API server has full visibility and control over every run.
-  #   - Without CRON_SCHEDULE, runs must be triggered manually via POST /start.
-  if [ -n "${CRON_SCHEDULE:-}" ]; then
+  #   - With neither source configured, runs must be triggered manually via
+  #     POST /start.
+  export TZ
+
+  SCHEDULE_OVERRIDE="${SCHEDULE_FILE:-$SCRIPT_DIR/config/schedule.json}"
+
+  if [ -f "$SCHEDULE_OVERRIDE" ]; then
+    echo "[entrypoint] Found $SCHEDULE_OVERRIDE — applying it (overrides CRON_SCHEDULE)."
+    if node scripts/api/apply-schedule.js; then
+      cron -f &
+      echo "[entrypoint] Cron started in background (schedule: from schedule.json, TZ: $TZ)"
+    else
+      echo "ERROR: Could not apply $SCHEDULE_OVERRIDE." >&2
+      exit 1
+    fi
+  elif [ -n "${CRON_SCHEDULE:-}" ]; then
     if [ ! -f /etc/cron.d/microsoft-rewards-cron.template ]; then
       echo "ERROR: Cron template /etc/cron.d/microsoft-rewards-cron.template not found." >&2
       exit 1
     fi
-    export TZ
     envsubst < /etc/cron.d/microsoft-rewards-cron.template > /etc/cron.d/microsoft-rewards-cron
     chmod 0644 /etc/cron.d/microsoft-rewards-cron
     crontab /etc/cron.d/microsoft-rewards-cron
     cron -f &
     echo "[entrypoint] Cron started in background (schedule: $CRON_SCHEDULE, TZ: $TZ)"
   else
-    echo "[entrypoint] No CRON_SCHEDULE set — runs must be triggered manually via POST /start"
+    echo "[entrypoint] No CRON_SCHEDULE set and no schedule.json override — runs must be triggered manually via POST /start, or scheduled from the dashboard."
   fi
   echo "[entrypoint] Starting control API on ${API_HOST}:${API_PORT:-3010} at $(date)"
   exec node scripts/api/server.js

--- a/scripts/docker/schedule-store.js
+++ b/scripts/docker/schedule-store.js
@@ -1,0 +1,33 @@
+// Persisted override, stored inside the already-mounted ./config volume,
+// so no new compose mount is required.
+const SCHEDULE_FILE = envStr('SCHEDULE_FILE') ?? path.join(projectRoot, 'config', 'schedule.json')
+
+function readSchedule() {
+  if (fs.existsSync(SCHEDULE_FILE)) {
+    return JSON.parse(fs.readFileSync(SCHEDULE_FILE, 'utf8'))  // source: 'override'
+  }
+  // Fall back to the env-configured default so nothing breaks for
+  // no-frontend users who only ever set CRON_SCHEDULE.
+  return {
+    enabled: Boolean(process.env.CRON_SCHEDULE),
+    cron: process.env.CRON_SCHEDULE || null,
+    skipIfRunning: true,
+    excludedAccountIndexes: [],
+    source: 'env'
+  }
+}
+
+function writeSchedule(next) {
+  writeConfigAtomic(SCHEDULE_FILE, next)   // reuse the atomic-write helper already in configEditor.js
+  applyCrontab(next)                        // regenerate /etc/cron.d file + `crontab` it live
+}
+
+function applyCrontab({ enabled, cron }) {
+  if (!enabled || !cron) return execSync('crontab -r', { stdio: 'ignore' }) // no-op if none exists
+  const template = fs.readFileSync('/etc/cron.d/microsoft-rewards-cron.template', 'utf8')
+  const rendered = template
+    .replace('${CRON_SCHEDULE}', cron)
+    .replace('${TZ}', process.env.TZ || 'UTC')
+  fs.writeFileSync('/etc/cron.d/microsoft-rewards-cron', rendered, { mode: 0o644 })
+  execSync('crontab /etc/cron.d/microsoft-rewards-cron')
+}


### PR DESCRIPTION
This PR adds API endpoints and supporting control files to allow the API to read and modify the in-built docker scheduler.  This only applies to docker-based deployments of the script.

The added API endpoints and supporting scripts then allow the docker scheduler to optionally be read and/or modified by API calls. API access to the scheduler is opt-in only via `API_ALLOW_SCHEDULE_WRITE: true`, similar to the config write opt-in. 

Without API_MODE enabled, a docker user can set a schedule in the `compose.yaml`, as normal. 