### PR TITLE
fix: avoid warning for Bing home page

### DIFF
--- a/src/browser/auth/Login.ts
+++ b/src/browser/auth/Login.ts
@@ -559,17 +559,19 @@ export class Login {
 
                 this.bot.logger.debug(this.bot.isMobile, 'LOGIN-BING', `Verification loop ${i + 1}/${loopMax}`)
 
-                const state = await this.detectCurrentState(page)
-                if (state === 'PASSKEY_ERROR') {
-                    this.bot.logger.info(this.bot.isMobile, 'LOGIN-BING', 'Dismissing Passkey error state')
-                    await this.bot.browser.utils.ghostClick(page, this.selectors.secondaryButton)
-                }
-
-                // Handle stats in case of password etc
-                await this.handleState(state, page, account)
-
                 const u = new URL(page.url())
                 const atBingHome = u.hostname === 'www.bing.com' && u.pathname === '/'
+                if (!atBingHome) {
+                    const state = await this.detectCurrentState(page)
+                    if (state === 'PASSKEY_ERROR') {
+                        this.bot.logger.info(this.bot.isMobile, 'LOGIN-BING', 'Dismissing Passkey error state')
+                        await this.bot.browser.utils.ghostClick(page, this.selectors.secondaryButton)
+                    }
+
+                    // Handle stats in case of password etc
+                    await this.handleState(state, page, account)
+                }
+
                 this.bot.logger.debug(
                     this.bot.isMobile,
                     'LOGIN-BING',


### PR DESCRIPTION
## Summary

- Avoid reporting the normal Bing home page as an unknown login state.
- Prevent unnecessary unknown-page diagnostics during successful Bing session verification.

## Root cause

`verifyBingSession()` called the generic login-state detection before checking whether the browser had already reached `www.bing.com/`.

The normal Bing home page does not contain the login-page selectors used by `detectCurrentState()`, so it was reported as `UNKNOWN`. The same loop then correctly recognized the Bing home page and verified the session successfully.

This caused a misleading warning:

```text
Unknown state at www.bing.com/, waiting
```

### Changes

- Check whether the current page is the Bing home page before running generic login-state detection.
- Continue handling password, Passkey, and other login states on non-home pages.
- Keep the existing Bing session verification behavior unchanged.

### Testing

- Verified the issue using the reported login logs.
- Confirmed that the normal Bing home page no longer enters the UNKNOWN state handler.
- Confirmed that non-home login pages still use the existing state detection flow.