### PR TITLE
Increase timeout for waitForSelector in Login.ts

### DIFF
--- a/src/browser/auth/Login.ts
+++ b/src/browser/auth/Login.ts
@@ -322,7 +322,7 @@ export class Login {
 
     private async checkSelector(page: Page, selector: string): Promise<boolean> {
         return page
-            .waitForSelector(selector, { state: 'visible', timeout: 200 })
+            .waitForSelector(selector, { state: 'visible', timeout: 5000 })
             .then(() => true)
             .catch(() => false)
     }


### PR DESCRIPTION
Makes the script work for slower devices, while not sacrificing speed for quicker devices as its a wait for, not always 5s