### PR TITLE
fix: dismiss first-time Rewards welcome modal

### DIFF
--- a/src/browser/BrowserFunc.ts
+++ b/src/browser/BrowserFunc.ts
@@ -275,6 +275,9 @@ export default class BrowserFunc {
             // /earn is the offers page
             await page.goto(URLs.rewards.earn, { waitUntil: 'domcontentloaded' })
 
+            // first-time welcome modal blocks the dashboard from rendering
+            await this.dismissRewardsWelcomeDialog(page)
+
             const earnDom = await page.content()
             const earnRaw = await this.fetchBootstrapHtml(page, URLs.rewards.earn, '/earn')
 
@@ -336,6 +339,30 @@ export default class BrowserFunc {
                 `Failed acquiring context | error=${error instanceof Error ? error.message : String(error)}`
             )
             throw error
+        }
+    }
+
+    /**
+     * Dismisses the first-time welcome modal on /earn, which otherwise
+     * prevents section#dailyset from rendering.
+     */
+    private async dismissRewardsWelcomeDialog(page: Page): Promise<void> {
+        try {
+            const welcomeButton = await page
+                .waitForSelector('section[role="dialog"] button[slot="close"]', { timeout: 5000 })
+                .catch(() => null)
+            if (!welcomeButton) return
+
+            await welcomeButton.click({ timeout: 5000 })
+            this.bot.logger.info(this.bot.isMobile, 'BOOTSTRAP', 'Dismissed welcome dialog')
+
+            await page.waitForSelector('section#dailyset', { timeout: 15000 }).catch(() => undefined)
+        } catch (error) {
+            this.bot.logger.warn(
+                this.bot.isMobile,
+                'BOOTSTRAP',
+                `Failed to dismiss welcome dialog: ${error instanceof Error ? error.message : String(error)}`
+            )
         }
     }
 


### PR DESCRIPTION
Problem: When an account (or a fresh browser context) visits  /earn  for the first time, a full-screen "Welcome" modal is shown (e.g. "Welcome to Microsoft Rewards — Earn gift cards, sweepstakes entries, and more" with a "Get started" button). While this modal is open, the dashboard does not render  section#dailyset , so  bootstrap()  aborts with a false  Rewards dashboard did not render  error and the whole login is treated as failed.
 
Fix: Before inspecting the DOM in  bootstrap() , wait briefly for the modal and click its confirm button (targeted via  slot="close" , locale-independent), then wait up to 15s for  section#dailyset  to render. No-op for accounts that don't see the modal.
 
Evidence: error diagnostics captured  page.content()  and a screenshot of the failing state — the page shows the logged-in dashboard (points balance rendered, RSC payload contains the account's dailyset offers) hidden behind the modal.See attached screenshot for details. Sorry I forgot to take the screenshot in English.

<img width="100" alt="Screenshot_20260902_012424" src="https://github.com/user-attachments/assets/ddb6df84-c6d8-4877-b1cd-639f67cbb64b" />
